### PR TITLE
Port to recent zenoh sync Rust API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ name = "zenoh"
 crate-type = ["cdylib"]
 
 [dependencies]
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh", branch="sync" }
+zenoh = { git = "https://github.com/eclipse-zenoh/zenoh" }
 async-std = "=1.9.0"
 uhlc = "0.3"
 futures = "0.3.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,9 @@ name = "zenoh"
 crate-type = ["cdylib"]
 
 [dependencies]
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh" }
+zenoh = { git = "https://github.com/eclipse-zenoh/zenoh", branch="sync" }
 async-std = "=1.9.0"
-uhlc = "0.2"
+uhlc = "0.3"
 futures = "0.3.12"
 log = "0.4"
 env_logger = "0.8.2"

--- a/examples/zenoh/z_eval.py
+++ b/examples/zenoh/z_eval.py
@@ -86,7 +86,9 @@ def eval_callback(get_request):
             name = dataset[0].value.get_content()
 
     print('   >> Replying string: "Eval from {}"'.format(name))
-    get_request.reply(path, 'Eval from {}'.format(name))
+    get_request.reply(path, '#1Eval from {}'.format(name))
+    get_request.reply(path, '#2Eval from {}'.format(name))
+    get_request.reply(path, '#3Eval from {}'.format(name))
 
 
 print("Register eval for '{}'...".format(path))

--- a/src/types.rs
+++ b/src/types.rs
@@ -592,7 +592,7 @@ impl GetRequest {
     fn reply(&self, path: String, value: &PyAny) -> PyResult<()> {
         let p = path_of_string(path)?;
         let v = zvalue_of_pyany(value)?;
-        task::block_on(self.r.reply(p, v));
+        self.r.reply(p, v);
         Ok(())
     }
 }

--- a/src/zenoh_net/mod.rs
+++ b/src/zenoh_net/mod.rs
@@ -215,9 +215,11 @@ fn open(config: &PyDict) -> PyResult<Session> {
 fn scout(whatami: ZInt, config: &PyDict, scout_duration: f64) -> PyResult<Vec<Hello>> {
     task::block_on(async move {
         let mut result = Vec::<Hello>::new();
-        let mut stream = zenoh::net::scout(whatami, pydict_to_props(config).into()).await;
+        let mut receiver = zenoh::net::scout(whatami, pydict_to_props(config).into())
+            .await
+            .unwrap();
         let scout = async {
-            while let Some(h) = stream.next().await {
+            while let Some(h) = receiver.next().await {
                 result.push(Hello { h })
             }
         };

--- a/src/zenoh_net/types.rs
+++ b/src/zenoh_net/types.rs
@@ -20,6 +20,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyTuple};
 use pyo3::PyObjectProtocol;
 use zenoh::net::{ResourceId, ZInt};
+use zenoh::ZFuture;
 
 // zenoh.net.config (simulate the package as a class, and consts as class attributes)
 /// Constants and helpers to build the configuration to pass to :func:`zenoh.net.open`.
@@ -663,7 +664,7 @@ impl Publisher {
     /// Undeclare the publisher.
     fn undeclare(&mut self) -> PyResult<()> {
         match self.p.take() {
-            Some(p) => task::block_on(p.undeclare()).map_err(to_pyerr),
+            Some(p) => p.undeclare().wait().map_err(to_pyerr),
             None => Ok(()),
         }
     }
@@ -768,7 +769,7 @@ impl Query {
     /// :type: Sample
     #[text_signature = "(self, sample)"]
     fn reply(&self, sample: Sample) {
-        task::block_on(self.q.reply(sample.s));
+        self.q.reply(sample.s);
     }
 }
 


### PR DESCRIPTION
This PR make zenoh-python to use the zenoh sync Rust API introduced by eclipse-zenoh/zenoh#95