### PR TITLE
fix examples

### DIFF
--- a/examples/z_delete.py
+++ b/examples/z_delete.py
@@ -13,6 +13,7 @@
 import sys
 import time
 import argparse
+import json
 import zenoh
 from zenoh import config
 
@@ -46,11 +47,11 @@ parser.add_argument('--config', '-c', dest='config',
 args = parser.parse_args()
 conf = zenoh.config_from_file(args.config) if args.config is not None else zenoh.Config()
 if args.mode is not None:
-    conf.insert_json5("mode", args.mode)
+    conf.insert_json5("mode", json.dumps(args.mode))
 if args.peer is not None:
-    conf.insert_json5("peers", f"[{','.join(args.peer)}]")
+    conf.insert_json5("peers", json.dumps(args.peer))
 if args.listener is not None:
-    conf.insert_json5("listeners", f"[{','.join(args.listener)}]")
+    conf.insert_json5("listeners", json.dumps(args.listener))
 key = args.key
 
 # zenoh-net code  --- --- --- --- --- --- --- --- --- --- ---

--- a/examples/z_eval.py
+++ b/examples/z_eval.py
@@ -13,6 +13,7 @@
 import sys
 import time
 import argparse
+import json
 import zenoh
 from zenoh import config, Sample
 from zenoh.queryable import EVAL
@@ -51,11 +52,11 @@ parser.add_argument('--config', '-c', dest='config',
 args = parser.parse_args()
 conf = zenoh.config_from_file(args.config) if args.config is not None else zenoh.Config()
 if args.mode is not None:
-    conf.insert_json5("mode", args.mode)
+    conf.insert_json5("mode", json.dumps(args.mode))
 if args.peer is not None:
-    conf.insert_json5("peers", f"[{','.join(args.peer)}]")
+    conf.insert_json5("peers", json.dumps(args.peer))
 if args.listener is not None:
-    conf.insert_json5("listeners", f"[{','.join(args.listener)}]")
+    conf.insert_json5("listeners", json.dumps(args.listener))
 key = args.key
 value = args.value
 

--- a/examples/z_get.py
+++ b/examples/z_get.py
@@ -13,6 +13,7 @@
 import sys
 import time
 import argparse
+import json
 import zenoh
 from zenoh import config, queryable, QueryTarget, Target
 
@@ -56,11 +57,11 @@ parser.add_argument('--config', '-c', dest='config',
 args = parser.parse_args()
 conf = zenoh.config_from_file(args.config) if args.config is not None else zenoh.Config()
 if args.mode is not None:
-    conf.insert_json5("mode", args.mode)
+    conf.insert_json5("mode", json.dumps(args.mode))
 if args.peer is not None:
-    conf.insert_json5("peers", f"[{','.join(args.peer)}]")
+    conf.insert_json5("peers", json.dumps(args.peer))
 if args.listener is not None:
-    conf.insert_json5("listeners", f"[{','.join(args.listener)}]")
+    conf.insert_json5("listeners", json.dumps(args.listener))
 selector = args.selector
 kind = {
     'ALL_KINDS': queryable.ALL_KINDS,

--- a/examples/z_info.py
+++ b/examples/z_info.py
@@ -13,6 +13,7 @@
 import sys
 import time
 import argparse
+import json
 import zenoh
 from zenoh import config
 
@@ -42,11 +43,11 @@ parser.add_argument('--config', '-c', dest='config',
 args = parser.parse_args()
 conf = zenoh.config_from_file(args.config) if args.config is not None else zenoh.Config()
 if args.mode is not None:
-    conf["mode"] = args.mode
+    conf.insert_json5("mode", json.dumps(args.mode))
 if args.peer is not None:
-    conf["peer"] = ",".join(args.peer)
+    conf.insert_json5("peers", json.dumps(args.peer))
 if args.listener is not None:
-    conf["listener"] = ",".join(args.listener)
+    conf.insert_json5("listeners", json.dumps(args.listener))
 # zenoh-net code  --- --- --- --- --- --- --- --- --- --- ---
 
 # initiate logging

--- a/examples/z_pub.py
+++ b/examples/z_pub.py
@@ -14,6 +14,7 @@ import sys
 import time
 import argparse
 import itertools
+import json
 import zenoh
 from zenoh import config
 
@@ -52,11 +53,11 @@ parser.add_argument('--config', '-c', dest='config',
 args = parser.parse_args()
 conf = zenoh.config_from_file(args.config) if args.config is not None else zenoh.Config()
 if args.mode is not None:
-    conf.insert_json5("mode", args.mode)
+    conf.insert_json5("mode", json.dumps(args.mode))
 if args.peer is not None:
-    conf.insert_json5("peers", f"[{','.join(args.peer)}]")
+    conf.insert_json5("peers", json.dumps(args.peer))
 if args.listener is not None:
-    conf.insert_json5("listeners", f"[{','.join(args.listener)}]")
+    conf.insert_json5("listeners", json.dumps(args.listener))
 key = args.key
 value = args.value
 

--- a/examples/z_pub_thr.py
+++ b/examples/z_pub_thr.py
@@ -13,6 +13,7 @@
 import sys
 import time
 import argparse
+import json
 import zenoh
 from zenoh import config, CongestionControl
 
@@ -45,11 +46,11 @@ parser.add_argument('--config', '-c', dest='config',
 args = parser.parse_args()
 conf = zenoh.config_from_file(args.config) if args.config is not None else zenoh.Config()
 if args.mode is not None:
-    conf.insert_json5("mode", args.mode)
+    conf.insert_json5("mode", json.dumps(args.mode))
 if args.peer is not None:
-    conf.insert_json5("peers", f"[{','.join(args.peer)}]")
+    conf.insert_json5("peers", json.dumps(args.peer))
 if args.listener is not None:
-    conf.insert_json5("listeners", f"[{','.join(args.listener)}]")
+    conf.insert_json5("listeners", json.dumps(args.listener))
 size = args.payload_size
 
 # zenoh-net code  --- --- --- --- --- --- --- --- --- --- ---

--- a/examples/z_pull.py
+++ b/examples/z_pull.py
@@ -14,6 +14,7 @@ import sys
 import time
 from datetime import datetime
 import argparse
+import json
 import zenoh
 from zenoh import Reliability, SubMode
 
@@ -47,11 +48,11 @@ parser.add_argument('--config', '-c', dest='config',
 args = parser.parse_args()
 conf = zenoh.config_from_file(args.config) if args.config is not None else zenoh.Config()
 if args.mode is not None:
-    conf.insert_json5("mode", args.mode)
+    conf.insert_json5("mode", json.dumps(args.mode))
 if args.peer is not None:
-    conf.insert_json5("peers", f"[{','.join(args.peer)}]")
+    conf.insert_json5("peers", json.dumps(args.peer))
 if args.listener is not None:
-    conf.insert_json5("listeners", f"[{','.join(args.listener)}]")
+    conf.insert_json5("listeners", json.dumps(args.listener))
 key = args.key
 
 # zenoh-net code  --- --- --- --- --- --- --- --- --- --- ---

--- a/examples/z_put.py
+++ b/examples/z_put.py
@@ -13,6 +13,7 @@
 import sys
 import time
 import argparse
+import json
 import zenoh
 from zenoh import config
 
@@ -50,11 +51,11 @@ parser.add_argument('--config', '-c', dest='config',
 args = parser.parse_args()
 conf = zenoh.config_from_file(args.config) if args.config is not None else zenoh.Config()
 if args.mode is not None:
-    conf.insert_json5("mode", args.mode)
+    conf.insert_json5("mode", json.dumps(args.mode))
 if args.peer is not None:
-    conf.insert_json5("peers", f"[{','.join(args.peer)}]")
+    conf.insert_json5("peers", json.dumps(args.peer))
 if args.listener is not None:
-    conf.insert_json5("listeners", f"[{','.join(args.listener)}]")
+    conf.insert_json5("listeners", json.dumps(args.listener))
 key = args.key
 value = args.value
 

--- a/examples/z_put_float.py
+++ b/examples/z_put_float.py
@@ -14,6 +14,7 @@ import sys
 import time
 import argparse
 import math
+import json
 import zenoh
 from zenoh import config
 
@@ -51,11 +52,11 @@ parser.add_argument('--config', '-c', dest='config',
 args = parser.parse_args()
 conf = zenoh.config_from_file(args.config) if args.config is not None else zenoh.Config()
 if args.mode is not None:
-    conf.insert_json5("mode", args.mode)
+    conf.insert_json5("mode", json.dumps(args.mode))
 if args.peer is not None:
-    conf.insert_json5("peers", f"[{','.join(args.peer)}]")
+    conf.insert_json5("peers", json.dumps(args.peer))
 if args.listener is not None:
-    conf.insert_json5("listeners", f"[{','.join(args.listener)}]")
+    conf.insert_json5("listeners", json.dumps(args.listener))
 key = args.key
 value = args.value
 

--- a/examples/z_storage.py
+++ b/examples/z_storage.py
@@ -13,6 +13,7 @@
 import sys
 import time
 import argparse
+import json
 import zenoh
 from zenoh import Reliability, SampleKind, SubMode, Sample, KeyExpr
 from zenoh.queryable import STORAGE
@@ -47,11 +48,11 @@ parser.add_argument('--config', '-c', dest='config',
 args = parser.parse_args()
 conf = zenoh.config_from_file(args.config) if args.config is not None else zenoh.Config()
 if args.mode is not None:
-    conf.insert_json5("mode", args.mode)
+    conf.insert_json5("mode", json.dumps(args.mode))
 if args.peer is not None:
-    conf.insert_json5("peers", f"[{','.join(args.peer)}]")
+    conf.insert_json5("peers", json.dumps(args.peer))
 if args.listener is not None:
-    conf.insert_json5("listeners", f"[{','.join(args.listener)}]")
+    conf.insert_json5("listeners", json.dumps(args.listener))
 key = args.key
 
 # zenoh-net code  --- --- --- --- --- --- --- --- --- --- ---

--- a/examples/z_sub.py
+++ b/examples/z_sub.py
@@ -14,6 +14,7 @@ import sys
 import time
 from datetime import datetime
 import argparse
+import json
 import zenoh
 from zenoh import Reliability, SubMode
 
@@ -47,11 +48,11 @@ parser.add_argument('--config', '-c', dest='config',
 args = parser.parse_args()
 conf = zenoh.config_from_file(args.config) if args.config is not None else zenoh.Config()
 if args.mode is not None:
-    conf.insert_json5("mode", args.mode)
+    conf.insert_json5("mode", json.dumps(args.mode))
 if args.peer is not None:
-    conf.insert_json5("peers", f"[{','.join(args.peer)}]")
+    conf.insert_json5("peers", json.dumps(args.peer))
 if args.listener is not None:
-    conf.insert_json5("listeners", f"[{','.join(args.listener)}]")
+    conf.insert_json5("listeners", json.dumps(args.listener))
 key = args.key
 
 # zenoh-net code  --- --- --- --- --- --- --- --- --- --- ---

--- a/examples/z_sub_thr.py
+++ b/examples/z_sub_thr.py
@@ -14,6 +14,7 @@ import sys
 import time
 import datetime
 import argparse
+import json
 import zenoh
 from zenoh import  Reliability, SubMode
 
@@ -55,11 +56,11 @@ parser.add_argument('--config', '-c', dest='config',
 args = parser.parse_args()
 conf = zenoh.config_from_file(args.config) if args.config is not None else zenoh.Config()
 if args.mode is not None:
-    conf.insert_json5("mode", args.mode)
+    conf.insert_json5("mode", json.dumps(args.mode))
 if args.peer is not None:
-    conf.insert_json5("peers", f"[{','.join(args.peer)}]")
+    conf.insert_json5("peers", json.dumps(args.peer))
 if args.listener is not None:
-    conf.insert_json5("listeners", f"[{','.join(args.listener)}]")
+    conf.insert_json5("listeners", json.dumps(args.listener))
 m = args.samples
 n = args.number
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,8 +183,13 @@ impl Config {
         }
     }
 
-    pub fn insert_json5(&mut self, key: &str, value: &str) -> bool {
-        self.inner.insert_json(key, value).is_ok()
+    pub fn insert_json5(&mut self, key: &str, value: &str) -> PyResult<()> {
+        match self.inner.insert_json(key, value) {
+            Ok(()) => Ok(()),
+            Err(e) => Err(PyErr::new::<pyo3::exceptions::PyException, _>(
+                e.to_string(),
+            )),
+        }
     }
     pub fn json(&self) -> String {
         serde_json::to_string(&self.inner).unwrap()


### PR DESCRIPTION
`--listener` option has no effect in examples.
Cause: error in json format when adding options to the config.