### PR TITLE
Asyncronous API for usage with asyncio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2378,7 +2378,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#4b4f106dbd6231f6817943bc9cdc41d1fd40ada2"
 dependencies = [
  "async-global-executor",
  "async-std",
@@ -2424,7 +2424,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#4b4f106dbd6231f6817943bc9cdc41d1fd40ada2"
 dependencies = [
  "async-std",
  "bincode",
@@ -2439,7 +2439,7 @@ dependencies = [
 [[package]]
 name = "zenoh-cfg-properties"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#4b4f106dbd6231f6817943bc9cdc41d1fd40ada2"
 dependencies = [
  "zenoh-core",
  "zenoh-macros",
@@ -2448,7 +2448,7 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#4b4f106dbd6231f6817943bc9cdc41d1fd40ada2"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2461,7 +2461,7 @@ dependencies = [
 [[package]]
 name = "zenoh-config"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#4b4f106dbd6231f6817943bc9cdc41d1fd40ada2"
 dependencies = [
  "flume",
  "json5",
@@ -2478,7 +2478,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#4b4f106dbd6231f6817943bc9cdc41d1fd40ada2"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -2487,7 +2487,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#4b4f106dbd6231f6817943bc9cdc41d1fd40ada2"
 dependencies = [
  "aes",
  "hmac",
@@ -2500,7 +2500,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#4b4f106dbd6231f6817943bc9cdc41d1fd40ada2"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2519,7 +2519,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#4b4f106dbd6231f6817943bc9cdc41d1fd40ada2"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2534,7 +2534,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#4b4f106dbd6231f6817943bc9cdc41d1fd40ada2"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2553,7 +2553,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#4b4f106dbd6231f6817943bc9cdc41d1fd40ada2"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2568,7 +2568,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#4b4f106dbd6231f6817943bc9cdc41d1fd40ada2"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -2586,7 +2586,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#4b4f106dbd6231f6817943bc9cdc41d1fd40ada2"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2603,7 +2603,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#4b4f106dbd6231f6817943bc9cdc41d1fd40ada2"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2619,7 +2619,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#4b4f106dbd6231f6817943bc9cdc41d1fd40ada2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2631,7 +2631,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#4b4f106dbd6231f6817943bc9cdc41d1fd40ada2"
 dependencies = [
  "libloading",
  "log",
@@ -2644,7 +2644,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#4b4f106dbd6231f6817943bc9cdc41d1fd40ada2"
 dependencies = [
  "log",
  "uhlc",
@@ -2656,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol-core"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#4b4f106dbd6231f6817943bc9cdc41d1fd40ada2"
 dependencies = [
  "hex",
  "lazy_static",
@@ -2669,7 +2669,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#4b4f106dbd6231f6817943bc9cdc41d1fd40ada2"
 dependencies = [
  "async-std",
  "event-listener",
@@ -2681,7 +2681,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#4b4f106dbd6231f6817943bc9cdc41d1fd40ada2"
 dependencies = [
  "async-global-executor",
  "async-std",
@@ -2707,7 +2707,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+source = "git+https://github.com/eclipse-zenoh/zenoh#4b4f106dbd6231f6817943bc9cdc41d1fd40ada2"
 dependencies = [
  "async-std",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f06685bad74e0570f5213741bea82158279a4103d988e57bfada11ad230341"
+checksum = "f8056f1455169ab86dd47b47391e4ab0cbd25410a70e9fe675544f49bafaf952"
 dependencies = [
  "async-attributes",
  "async-channel",
@@ -656,6 +656,7 @@ dependencies = [
  "json5",
  "log",
  "pyo3",
+ "pyo3-asyncio",
  "serde_json",
  "uhlc",
  "validated_struct",
@@ -885,6 +886,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghost"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5bcf1bbeab73aa4cf2fde60a846858dc036163c7c33bec309f8d17de785479"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "git-version"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,6 +1082,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "inventory"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0eb5160c60ba1e809707918ee329adb99d222888155835c6feedba19f6c3fd4"
+dependencies = [
+ "ctor",
+ "ghost",
+ "inventory-impl",
+]
+
+[[package]]
+name = "inventory-impl"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e41b53715c6f0c4be49510bb82dee2c1e51c8586d885abe65396e82ed518548"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1699,6 +1733,32 @@ dependencies = [
  "pyo3-build-config",
  "pyo3-macros",
  "unindent",
+]
+
+[[package]]
+name = "pyo3-asyncio"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0897c7e36110a32b726b975359b2bbe90c37fcf1266046d3b1c08c616a47a886"
+dependencies = [
+ "async-std",
+ "futures",
+ "inventory",
+ "once_cell",
+ "pin-project-lite",
+ "pyo3",
+ "pyo3-asyncio-macros",
+]
+
+[[package]]
+name = "pyo3-asyncio-macros"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4daada7260db6d6dbc1f9b50f3e3d21f9eb28c034722c9a61ac05ff56ffd62db"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2838,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#26a721f5bd09551ae5af845fba444389be663055"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10#2155f0686f1ec4235ed14e4ab6f775423ddad8db"
 dependencies = [
  "async-global-executor",
  "async-rustls",
@@ -2890,7 +2950,7 @@ dependencies = [
 [[package]]
 name = "zenoh-cfg-properties"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#26a721f5bd09551ae5af845fba444389be663055"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10#2155f0686f1ec4235ed14e4ab6f775423ddad8db"
 dependencies = [
  "zenoh-core",
  "zenoh-macros",
@@ -2899,7 +2959,7 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#26a721f5bd09551ae5af845fba444389be663055"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10#2155f0686f1ec4235ed14e4ab6f775423ddad8db"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2912,7 +2972,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#26a721f5bd09551ae5af845fba444389be663055"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10#2155f0686f1ec4235ed14e4ab6f775423ddad8db"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -2921,7 +2981,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#26a721f5bd09551ae5af845fba444389be663055"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10#2155f0686f1ec4235ed14e4ab6f775423ddad8db"
 dependencies = [
  "aes 0.7.5",
  "hmac 0.11.0",
@@ -2934,7 +2994,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#26a721f5bd09551ae5af845fba444389be663055"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10#2155f0686f1ec4235ed14e4ab6f775423ddad8db"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2946,7 +3006,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#26a721f5bd09551ae5af845fba444389be663055"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10#2155f0686f1ec4235ed14e4ab6f775423ddad8db"
 dependencies = [
  "libloading",
  "log",
@@ -2959,7 +3019,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#26a721f5bd09551ae5af845fba444389be663055"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10#2155f0686f1ec4235ed14e4ab6f775423ddad8db"
 dependencies = [
  "async-std",
  "event-listener",
@@ -2971,7 +3031,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh#26a721f5bd09551ae5af845fba444389be663055"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10#2155f0686f1ec4235ed14e4ab6f775423ddad8db"
 dependencies = [
  "async-std",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,68 +3,14 @@
 version = 3
 
 [[package]]
-name = "aead"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
-dependencies = [
- "generic-array 0.14.5",
-]
-
-[[package]]
-name = "aes"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
-dependencies = [
- "aes-soft",
- "aesni",
- "cipher 0.2.5",
-]
-
-[[package]]
 name = "aes"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if",
- "cipher 0.3.0",
+ "cipher",
  "cpufeatures",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "aes-gcm"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5278b5fabbb9bd46e24aa69b2fdea62c99088e0a950a9be40e3e0101298f88da"
-dependencies = [
- "aead",
- "aes 0.6.0",
- "cipher 0.2.5",
- "ctr",
- "ghash",
- "subtle",
-]
-
-[[package]]
-name = "aes-soft"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
-dependencies = [
- "cipher 0.2.5",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "aesni"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
-dependencies = [
- "cipher 0.2.5",
  "opaque-debug 0.3.0",
 ]
 
@@ -285,12 +231,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "base-x"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
-
-[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,25 +351,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "cipher"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
-dependencies = [
- "generic-array 0.14.5",
-]
-
-[[package]]
 name = "cipher"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,29 +390,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
 
 [[package]]
-name = "const_fn"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
-
-[[package]]
-name = "cookie"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
-dependencies = [
- "aes-gcm",
- "base64",
- "hkdf",
- "hmac 0.10.1",
- "percent-encoding",
- "rand 0.8.4",
- "sha2",
- "time",
- "version_check",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,12 +415,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpuid-bool"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,17 +431,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
 dependencies = [
  "generic-array 0.14.5",
- "rand_core 0.6.3",
- "subtle",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
-dependencies = [
- "generic-array 0.14.5",
+ "rand_core",
  "subtle",
 ]
 
@@ -580,15 +462,6 @@ checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
 dependencies = [
  "quote",
  "syn",
-]
-
-[[package]]
-name = "ctr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4a30d54f7443bf3d6191dcd486aca19e67cb3c49fa7a06a319966346707e7f"
-dependencies = [
- "cipher 0.2.5",
 ]
 
 [[package]]
@@ -639,12 +512,6 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
-
-[[package]]
-name = "discard"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "eclipse-zenoh"
@@ -716,16 +583,6 @@ dependencies = [
  "nanorand",
  "pin-project",
  "spin 0.9.2",
-]
-
-[[package]]
-name = "form_urlencoded"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
-dependencies = [
- "matches",
- "percent-encoding",
 ]
 
 [[package]]
@@ -853,17 +710,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
@@ -871,18 +717,8 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "ghash"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
-dependencies = [
- "opaque-debug 0.3.0",
- "polyval",
 ]
 
 [[package]]
@@ -959,32 +795,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hkdf"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ab2f639c231793c5f6114bdb9bbe50a7dbbfcd7c7c6bd8475dec2d991e964f"
-dependencies = [
- "digest 0.9.0",
- "hmac 0.10.1",
-]
-
-[[package]]
-name = "hmac"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
-dependencies = [
- "crypto-mac 0.10.1",
- "digest 0.9.0",
-]
-
-[[package]]
 name = "hmac"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
- "crypto-mac 0.11.1",
+ "crypto-mac",
  "digest 0.9.0",
 ]
 
@@ -998,43 +814,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-types"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
-dependencies = [
- "anyhow",
- "async-channel",
- "async-std",
- "base64",
- "cookie",
- "futures-lite",
- "infer",
- "pin-project-lite",
- "rand 0.7.3",
- "serde",
- "serde_json",
- "serde_qs",
- "serde_urlencoded",
- "url",
-]
-
-[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "idna"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
 
 [[package]]
 name = "indexmap"
@@ -1068,12 +851,6 @@ dependencies = [
  "syn",
  "unindent",
 ]
-
-[[package]]
-name = "infer"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
 name = "instant"
@@ -1219,12 +996,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
-name = "matches"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
-
-[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,7 +1038,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "729eb334247daa1803e0a094d0a5c55711b85571179f5ec6e53eccfdf7008958"
 dependencies = [
- "getrandom 0.2.4",
+ "getrandom",
 ]
 
 [[package]]
@@ -1318,7 +1089,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.4",
+ "rand",
  "smallvec",
  "zeroize",
 ]
@@ -1454,15 +1225,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947"
-dependencies = [
- "base64",
-]
-
-[[package]]
 name = "pem-rfc7468"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1470,12 +1232,6 @@ checksum = "84e93a3b1cc0510b03020f33f21e62acdde3dcaef432edc95bea377fbd4c2cd4"
 dependencies = [
  "base64ct",
 ]
-
-[[package]]
-name = "percent-encoding"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pest"
@@ -1688,17 +1444,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "polyval"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
-dependencies = [
- "cpuid-bool",
- "opaque-debug 0.3.0",
- "universal-hash",
-]
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1821,7 +1566,7 @@ checksum = "047aa96ec7ee6acabad7a1318dff72e9aff8994316bf2166c9b94cbec78ca54c"
 dependencies = [
  "bytes",
  "ct-logs",
- "rand 0.8.4",
+ "rand",
  "ring",
  "rustls",
  "rustls-native-certs",
@@ -1843,37 +1588,14 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.3",
- "rand_hc 0.3.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
 ]
 
 [[package]]
@@ -1883,16 +1605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -1901,16 +1614,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.4",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
@@ -1919,19 +1623,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
- "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rcgen"
-version = "0.8.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5911d1403f4143c9d56a702069d593e8d0f3fab880a85e103604d0893ea31ba7"
-dependencies = [
- "chrono",
- "pem",
- "ring",
- "yasna",
+ "rand_core",
 ]
 
 [[package]]
@@ -1949,7 +1641,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.4",
+ "getrandom",
  "redox_syscall",
 ]
 
@@ -2000,18 +1692,9 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand 0.8.4",
+ "rand",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
 ]
 
 [[package]]
@@ -2020,7 +1703,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.4",
+ "semver",
 ]
 
 [[package]]
@@ -2105,24 +1788,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -2156,29 +1824,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_qs"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
-dependencies = [
- "percent-encoding",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "serde_yaml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2203,34 +1848,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
-dependencies = [
- "sha1_smol",
-]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
 name = "sha3"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2251,7 +1868,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "nix 0.22.2",
- "rand 0.8.4",
+ "rand",
  "winapi",
 ]
 
@@ -2341,62 +1958,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "standback"
-version = "0.2.17"
+name = "stop-token"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
+checksum = "af91f480ee899ab2d9f8435bfdfc14d08a5754bd9d3fef1f1a1c23336aad6c8b"
 dependencies = [
- "version_check",
+ "async-channel",
+ "cfg-if",
+ "futures-core",
+ "pin-project-lite",
 ]
-
-[[package]]
-name = "stdweb"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
-dependencies = [
- "discard",
- "rustc_version 0.2.3",
- "stdweb-derive",
- "stdweb-internal-macros",
- "stdweb-internal-runtime",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "stdweb-derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-macros"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
-dependencies = [
- "base-x",
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-runtime"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "strsim"
@@ -2468,44 +2039,6 @@ checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "time"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
-dependencies = [
- "const_fn",
- "libc",
- "standback",
- "stdweb",
- "time-macros",
- "version_check",
- "winapi",
-]
-
-[[package]]
-name = "time-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
-dependencies = [
- "proc-macro-hack",
- "time-macros-impl",
-]
-
-[[package]]
-name = "time-macros-impl"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "standback",
  "syn",
 ]
 
@@ -2596,21 +2129,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2627,16 +2145,6 @@ name = "unindent"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
-
-[[package]]
-name = "universal-hash"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
-dependencies = [
- "generic-array 0.14.5",
- "subtle",
-]
 
 [[package]]
 name = "untrusted"
@@ -2656,25 +2164,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "url"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
-dependencies = [
- "form_urlencoded",
- "idna",
- "matches",
- "percent-encoding",
- "serde",
-]
-
-[[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.4",
+ "getrandom",
 ]
 
 [[package]]
@@ -2728,12 +2223,6 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -2887,26 +2376,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "yasna"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e262a29d0e61ccf2b6190d7050d4b237535fc76ce4c1210d9caa316f71dffa75"
-dependencies = [
- "chrono",
-]
-
-[[package]]
 name = "zenoh"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10#2155f0686f1ec4235ed14e4ab6f775423ddad8db"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
 dependencies = [
  "async-global-executor",
- "async-rustls",
  "async-std",
  "async-trait",
  "base64",
- "bincode",
- "clap",
  "env_logger",
  "event-listener",
  "flume",
@@ -2914,43 +2391,55 @@ dependencies = [
  "futures-lite",
  "git-version",
  "hex",
- "http-types",
- "json5",
  "lazy_static",
- "libloading",
  "log",
- "nix 0.23.1",
- "num-traits",
  "ordered-float",
- "paste 1.0.6",
  "petgraph",
- "quinn",
- "rand 0.8.4",
- "rcgen",
+ "rand",
  "regex",
- "rsa",
- "rustc_version 0.4.0",
+ "rustc_version",
  "serde",
  "serde_json",
- "serde_yaml",
- "shared_memory",
  "socket2 0.4.2",
+ "stop-token",
  "uhlc",
  "uuid",
  "validated_struct",
  "vec_map",
- "webpki 0.22.0",
+ "zenoh-buffers",
+ "zenoh-cfg-properties",
+ "zenoh-collections",
+ "zenoh-config",
+ "zenoh-core",
+ "zenoh-crypto",
+ "zenoh-link",
+ "zenoh-plugin-trait",
+ "zenoh-protocol",
+ "zenoh-protocol-core",
+ "zenoh-sync",
+ "zenoh-transport",
+ "zenoh-util",
+]
+
+[[package]]
+name = "zenoh-buffers"
+version = "0.6.0-dev.0"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+dependencies = [
+ "async-std",
+ "bincode",
+ "hex",
+ "log",
+ "serde",
+ "shared_memory",
  "zenoh-collections",
  "zenoh-core",
- "zenoh-plugin-trait",
- "zenoh-sync",
- "zenoh-util",
 ]
 
 [[package]]
 name = "zenoh-cfg-properties"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10#2155f0686f1ec4235ed14e4ab6f775423ddad8db"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
 dependencies = [
  "zenoh-core",
  "zenoh-macros",
@@ -2959,7 +2448,7 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10#2155f0686f1ec4235ed14e4ab6f775423ddad8db"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2970,9 +2459,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zenoh-config"
+version = "0.6.0-dev.0"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+dependencies = [
+ "flume",
+ "json5",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "validated_struct",
+ "zenoh-cfg-properties",
+ "zenoh-core",
+ "zenoh-protocol-core",
+ "zenoh-util",
+]
+
+[[package]]
 name = "zenoh-core"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10#2155f0686f1ec4235ed14e4ab6f775423ddad8db"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -2981,24 +2487,143 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10#2155f0686f1ec4235ed14e4ab6f775423ddad8db"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
 dependencies = [
- "aes 0.7.5",
- "hmac 0.11.0",
- "rand 0.8.4",
- "rand_chacha 0.3.1",
+ "aes",
+ "hmac",
+ "rand",
+ "rand_chacha",
  "sha3",
  "zenoh-core",
 ]
 
 [[package]]
+name = "zenoh-link"
+version = "0.6.0-dev.0"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+dependencies = [
+ "async-std",
+ "async-trait",
+ "zenoh-cfg-properties",
+ "zenoh-config",
+ "zenoh-core",
+ "zenoh-link-commons",
+ "zenoh-link-quic",
+ "zenoh-link-tcp",
+ "zenoh-link-tls",
+ "zenoh-link-udp",
+ "zenoh-link-unixsock_stream",
+ "zenoh-protocol-core",
+]
+
+[[package]]
+name = "zenoh-link-commons"
+version = "0.6.0-dev.0"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+dependencies = [
+ "async-std",
+ "async-trait",
+ "flume",
+ "zenoh-buffers",
+ "zenoh-cfg-properties",
+ "zenoh-core",
+ "zenoh-protocol",
+ "zenoh-protocol-core",
+]
+
+[[package]]
+name = "zenoh-link-quic"
+version = "0.6.0-dev.0"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+dependencies = [
+ "async-std",
+ "async-trait",
+ "log",
+ "quinn",
+ "webpki 0.22.0",
+ "zenoh-cfg-properties",
+ "zenoh-config",
+ "zenoh-core",
+ "zenoh-link-commons",
+ "zenoh-protocol-core",
+ "zenoh-sync",
+ "zenoh-util",
+]
+
+[[package]]
+name = "zenoh-link-tcp"
+version = "0.6.0-dev.0"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+dependencies = [
+ "async-std",
+ "async-trait",
+ "log",
+ "zenoh-core",
+ "zenoh-link-commons",
+ "zenoh-protocol-core",
+ "zenoh-sync",
+ "zenoh-util",
+]
+
+[[package]]
+name = "zenoh-link-tls"
+version = "0.6.0-dev.0"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+dependencies = [
+ "async-rustls",
+ "async-std",
+ "async-trait",
+ "log",
+ "zenoh-cfg-properties",
+ "zenoh-config",
+ "zenoh-core",
+ "zenoh-link-commons",
+ "zenoh-protocol-core",
+ "zenoh-sync",
+ "zenoh-util",
+]
+
+[[package]]
+name = "zenoh-link-udp"
+version = "0.6.0-dev.0"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+dependencies = [
+ "async-std",
+ "async-trait",
+ "log",
+ "socket2 0.4.2",
+ "zenoh-collections",
+ "zenoh-core",
+ "zenoh-link-commons",
+ "zenoh-protocol-core",
+ "zenoh-sync",
+ "zenoh-util",
+]
+
+[[package]]
+name = "zenoh-link-unixsock_stream"
+version = "0.6.0-dev.0"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+dependencies = [
+ "async-std",
+ "async-trait",
+ "log",
+ "nix 0.23.1",
+ "uuid",
+ "zenoh-core",
+ "zenoh-link-commons",
+ "zenoh-protocol-core",
+ "zenoh-sync",
+]
+
+[[package]]
 name = "zenoh-macros"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10#2155f0686f1ec4235ed14e4ab6f775423ddad8db"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "rustc_version 0.4.0",
+ "rustc_version",
  "syn",
  "unzip-n",
 ]
@@ -3006,7 +2631,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10#2155f0686f1ec4235ed14e4ab6f775423ddad8db"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
 dependencies = [
  "libloading",
  "log",
@@ -3017,9 +2642,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "zenoh-protocol"
+version = "0.6.0-dev.0"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+dependencies = [
+ "log",
+ "uhlc",
+ "zenoh-buffers",
+ "zenoh-core",
+ "zenoh-protocol-core",
+]
+
+[[package]]
+name = "zenoh-protocol-core"
+version = "0.6.0-dev.0"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+dependencies = [
+ "hex",
+ "lazy_static",
+ "serde",
+ "uhlc",
+ "uuid",
+ "zenoh-core",
+]
+
+[[package]]
 name = "zenoh-sync"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10#2155f0686f1ec4235ed14e4ab6f775423ddad8db"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
 dependencies = [
  "async-std",
  "event-listener",
@@ -3029,9 +2679,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "zenoh-transport"
+version = "0.6.0-dev.0"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
+dependencies = [
+ "async-global-executor",
+ "async-std",
+ "async-trait",
+ "flume",
+ "log",
+ "paste 1.0.6",
+ "rand",
+ "rsa",
+ "serde",
+ "zenoh-buffers",
+ "zenoh-cfg-properties",
+ "zenoh-collections",
+ "zenoh-config",
+ "zenoh-core",
+ "zenoh-crypto",
+ "zenoh-link",
+ "zenoh-protocol",
+ "zenoh-protocol-core",
+ "zenoh-sync",
+]
+
+[[package]]
 name = "zenoh-util"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10#2155f0686f1ec4235ed14e4ab6f775423ddad8db"
+source = "git+https://github.com/JEnoch/zenoh?branch=async_1_10-2#f310672bd78be13589327f813d24d87d6c77e4d7"
 dependencies = [
  "async-std",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,9 @@ complete_n = ["zenoh/complete_n"]
 # zenoh = { git = "https://github.com/eclipse-zenoh/zenoh" }
 # zenoh-cfg-properties = { git = "https://github.com/eclipse-zenoh/zenoh" }
 # zenoh-core = { git = "https://github.com/eclipse-zenoh/zenoh" }
-zenoh = { git = "https://github.com/JEnoch/zenoh", branch = "async_1_10" }
-zenoh-cfg-properties = { git = "https://github.com/JEnoch/zenoh", branch = "async_1_10" }
-zenoh-core = { git = "https://github.com/JEnoch/zenoh", branch = "async_1_10" }
+zenoh = { git = "https://github.com/JEnoch/zenoh", branch = "async_1_10-2" }
+zenoh-cfg-properties = { git = "https://github.com/JEnoch/zenoh", branch = "async_1_10-2" }
+zenoh-core = { git = "https://github.com/JEnoch/zenoh", branch = "async_1_10-2" }
 validated_struct = "0.1"
 json5 = "0.4.1"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,17 +33,21 @@ crate-type = ["cdylib"]
 complete_n = ["zenoh/complete_n"]
 
 [dependencies]
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh" }
-zenoh-cfg-properties = { git = "https://github.com/eclipse-zenoh/zenoh" }
-zenoh-core = { git = "https://github.com/eclipse-zenoh/zenoh" }
+# zenoh = { git = "https://github.com/eclipse-zenoh/zenoh" }
+# zenoh-cfg-properties = { git = "https://github.com/eclipse-zenoh/zenoh" }
+# zenoh-core = { git = "https://github.com/eclipse-zenoh/zenoh" }
+zenoh = { git = "https://github.com/JEnoch/zenoh", branch = "async_1_10" }
+zenoh-cfg-properties = { git = "https://github.com/JEnoch/zenoh", branch = "async_1_10" }
+zenoh-core = { git = "https://github.com/JEnoch/zenoh", branch = "async_1_10" }
 validated_struct = "0.1"
 json5 = "0.4.1"
 serde_json = "1.0"
-async-std = "=1.9.0"
+async-std = "=1.10.0"
 uhlc = "0.4.0"
 futures = "0.3.12"
 log = "0.4"
 env_logger = "0.9.0"
+pyo3-asyncio = { version = "0.15", features = ["attributes", "async-std-runtime"] }
 
 [dependencies.pyo3]
 version = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,12 +33,9 @@ crate-type = ["cdylib"]
 complete_n = ["zenoh/complete_n"]
 
 [dependencies]
-# zenoh = { git = "https://github.com/eclipse-zenoh/zenoh" }
-# zenoh-cfg-properties = { git = "https://github.com/eclipse-zenoh/zenoh" }
-# zenoh-core = { git = "https://github.com/eclipse-zenoh/zenoh" }
-zenoh = { git = "https://github.com/JEnoch/zenoh", branch = "async_1_10-2" }
-zenoh-cfg-properties = { git = "https://github.com/JEnoch/zenoh", branch = "async_1_10-2" }
-zenoh-core = { git = "https://github.com/JEnoch/zenoh", branch = "async_1_10-2" }
+zenoh = { git = "https://github.com/eclipse-zenoh/zenoh" }
+zenoh-cfg-properties = { git = "https://github.com/eclipse-zenoh/zenoh" }
+zenoh-core = { git = "https://github.com/eclipse-zenoh/zenoh" }
 validated_struct = "0.1"
 json5 = "0.4.1"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ authors = [
 ]
 
 edition = "2018"
-maintainer = "ADLINK zenoh team, <zenoh@adlink-labs.tech>"
 
 [lib]
 name = "zenoh"

--- a/examples/asyncio/z_delete.py
+++ b/examples/asyncio/z_delete.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2017, 2020 ADLINK Technology Inc.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ADLINK zenoh team, <zenoh@adlink-labs.tech>
+
+import asyncio
+import sys
+import time
+import argparse
+import json
+import zenoh
+from zenoh import config
+
+async def main():
+    # --- Command line argument parsing --- --- --- --- --- ---
+    parser = argparse.ArgumentParser(
+        prog='z_put',
+        description='zenoh put example')
+    parser.add_argument('--mode', '-m', dest='mode',
+                        choices=['peer', 'client'],
+                        type=str,
+                        help='The zenoh session mode.')
+    parser.add_argument('--peer', '-e', dest='peer',
+                        metavar='LOCATOR',
+                        action='append',
+                        type=str,
+                        help='Peer locators used to initiate the zenoh session.')
+    parser.add_argument('--listener', '-l', dest='listener',
+                        metavar='LOCATOR',
+                        action='append',
+                        type=str,
+                        help='Locators to listen on.')
+    parser.add_argument('--key', '-k', dest='key',
+                        default='/demo/example/zenoh-python-put',
+                        type=str,
+                        help='The key expression matching resources to delete.')
+    parser.add_argument('--config', '-c', dest='config',
+                        metavar='FILE',
+                        type=str,
+                        help='A configuration file.')
+
+    args = parser.parse_args()
+    conf = zenoh.config_from_file(args.config) if args.config is not None else zenoh.Config()
+    if args.mode is not None:
+        conf.insert_json5("mode", json.dumps(args.mode))
+    if args.peer is not None:
+        conf.insert_json5("peers", json.dumps(args.peer))
+    if args.listener is not None:
+        conf.insert_json5("listeners", json.dumps(args.listener))
+    key = args.key
+
+    # zenoh-net code  --- --- --- --- --- --- --- --- --- --- ---
+
+    # initiate logging
+    zenoh.init_logger()
+
+    print("Openning session...")
+    session = await zenoh.async_open(conf)
+
+    print("Deleting resources matching '{}'...".format(key))
+    await session.delete(key)
+
+    await session.close()
+
+asyncio.run(main())

--- a/examples/asyncio/z_eval.py
+++ b/examples/asyncio/z_eval.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2017, 2020 ADLINK Technology Inc.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ADLINK zenoh team, <zenoh@adlink-labs.tech>
+
+import asyncio
+import sys
+import time
+import argparse
+import json
+import zenoh
+from zenoh import config, Sample
+from zenoh.queryable import EVAL
+
+async def main():
+    # --- Command line argument parsing --- --- --- --- --- ---
+    parser = argparse.ArgumentParser(
+        prog='z_eval',
+        description='zenoh eval example')
+    parser.add_argument('--mode', '-m', dest='mode',
+                        choices=['peer', 'client'],
+                        type=str,
+                        help='The zenoh session mode.')
+    parser.add_argument('--peer', '-e', dest='peer',
+                        metavar='LOCATOR',
+                        action='append',
+                        type=str,
+                        help='Peer locators used to initiate the zenoh session.')
+    parser.add_argument('--listener', '-l', dest='listener',
+                        metavar='LOCATOR',
+                        action='append',
+                        type=str,
+                        help='Locators to listen on.')
+    parser.add_argument('--key', '-k', dest='key',
+                        default='/demo/example/zenoh-python-eval',
+                        type=str,
+                        help='The key expression matching queries to evaluate.')
+    parser.add_argument('--value', '-v', dest='value',
+                        default='Eval from Python!',
+                        type=str,
+                        help='The value to reply to queries.')
+    parser.add_argument('--config', '-c', dest='config',
+                        metavar='FILE',
+                        type=str,
+                        help='A configuration file.')
+
+    args = parser.parse_args()
+    conf = zenoh.config_from_file(args.config) if args.config is not None else zenoh.Config()
+    if args.mode is not None:
+        conf.insert_json5("mode", json.dumps(args.mode))
+    if args.peer is not None:
+        conf.insert_json5("peers", json.dumps(args.peer))
+    if args.listener is not None:
+        conf.insert_json5("listeners", json.dumps(args.listener))
+    key = args.key
+    value = args.value
+
+    # zenoh-net code  --- --- --- --- --- --- --- --- --- --- ---
+
+
+    def eval_callback(query):
+        print(">> [Queryable ] Received Query '{}'".format(query.selector))
+        query.reply(Sample(key_expr=key, payload=value.encode()))
+
+
+    # initiate logging
+    zenoh.init_logger()
+
+    print("Openning session...")
+    session = await zenoh.async_open(conf)
+
+    print("Creating Queryable on '{}'...".format(key))
+    queryable = await session.queryable(key, EVAL, eval_callback)
+
+    print("Enter 'q' to quit......")
+    c = '\0'
+    while c != 'q':
+        c = sys.stdin.read(1)
+        if c == '':
+            time.sleep(1)
+
+    await queryable.close()
+    await session.close()
+
+asyncio.run(main())

--- a/examples/asyncio/z_get.py
+++ b/examples/asyncio/z_get.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2017, 2020 ADLINK Technology Inc.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ADLINK zenoh team, <zenoh@adlink-labs.tech>
+
+import asyncio
+import sys
+import time
+import argparse
+import json
+import zenoh
+from zenoh import config, queryable, QueryTarget, Target
+
+async def main():
+    # --- Command line argument parsing --- --- --- --- --- ---
+    parser = argparse.ArgumentParser(
+        prog='z_get',
+        description='zenoh get example')
+    parser.add_argument('--mode', '-m', dest='mode',
+                        choices=['peer', 'client'],
+                        type=str,
+                        help='The zenoh session mode.')
+    parser.add_argument('--peer', '-e', dest='peer',
+                        metavar='LOCATOR',
+                        action='append',
+                        type=str,
+                        help='Peer locators used to initiate the zenoh session.')
+    parser.add_argument('--listener', '-l', dest='listener',
+                        metavar='LOCATOR',
+                        action='append',
+                        type=str,
+                        help='Locators to listen on.')
+    parser.add_argument('--selector', '-s', dest='selector',
+                        default='/demo/example/**',
+                        type=str,
+                        help='The selection of resources to query.')
+    parser.add_argument('--kind', '-k', dest='kind',
+                        choices=['ALL_KINDS', 'STORAGE', 'EVAL'],
+                        default='ALL_KINDS',
+                        type=str,
+                        help='The KIND of queryables to query.')
+    parser.add_argument('--target', '-t', dest='target',
+                        choices=['ALL', 'BEST_MATCHING', 'ALL_COMPLETE', 'NONE'],
+                        default='ALL',
+                        type=str,
+                        help='The target queryables of the query.')
+    parser.add_argument('--config', '-c', dest='config',
+                        metavar='FILE',
+                        type=str,
+                        help='A configuration file.')
+
+    args = parser.parse_args()
+    conf = zenoh.config_from_file(args.config) if args.config is not None else zenoh.Config()
+    if args.mode is not None:
+        conf.insert_json5("mode", json.dumps(args.mode))
+    if args.peer is not None:
+        conf.insert_json5("peers", json.dumps(args.peer))
+    if args.listener is not None:
+        conf.insert_json5("listeners", json.dumps(args.listener))
+    selector = args.selector
+    kind = {
+        'ALL_KINDS': queryable.ALL_KINDS,
+        'STORAGE': queryable.STORAGE,
+        'EVAL': queryable.EVAL}.get(args.kind)
+    target = {
+        'ALL': Target.All(),
+        'BEST_MATCHING': Target.BestMatching(),
+        'ALL_COMPLETE': Target.AllComplete(),
+        'NONE': Target.No()}.get(args.target)
+
+    # zenoh-net code  --- --- --- --- --- --- --- --- --- --- ---
+
+    # initiate logging
+    zenoh.init_logger()
+
+    print("Openning session...")
+    session = await zenoh.async_open(conf)
+
+    print("Sending Query '{}'...".format(selector))
+    replies = await session.get(selector, target=QueryTarget(kind, target))
+    for reply in replies:
+        print(">> Received ('{}': '{}')"
+            .format(reply.data.key_expr, reply.data.payload.decode("utf-8")))
+
+    await session.close()
+
+asyncio.run(main())

--- a/examples/asyncio/z_info.py
+++ b/examples/asyncio/z_info.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2017, 2020 ADLINK Technology Inc.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ADLINK zenoh team, <zenoh@adlink-labs.tech>
+
+import asyncio
+import sys
+import time
+import argparse
+import json
+import zenoh
+from zenoh import config
+
+async def main():
+    # --- Command line argument parsing --- --- --- --- --- ---
+    parser = argparse.ArgumentParser(
+        prog='z_info',
+        description='zenoh info example')
+    parser.add_argument('--mode', '-m', dest='mode',
+                        choices=['peer', 'client'],
+                        type=str,
+                        help='The zenoh session mode.')
+    parser.add_argument('--peer', '-e', dest='peer',
+                        metavar='LOCATOR',
+                        action='append',
+                        type=str,
+                        help='Peer locators used to initiate the zenoh session.')
+    parser.add_argument('--listener', '-l', dest='listener',
+                        metavar='LOCATOR',
+                        action='append',
+                        type=str,
+                        help='Locators to listen on.')
+    parser.add_argument('--config', '-c', dest='config',
+                        metavar='FILE',
+                        type=str,
+                        help='A configuration file.')
+
+    args = parser.parse_args()
+    conf = zenoh.config_from_file(args.config) if args.config is not None else zenoh.Config()
+    if args.mode is not None:
+        conf.insert_json5("mode", json.dumps(args.mode))
+    if args.peer is not None:
+        conf.insert_json5("peers", json.dumps(args.peer))
+    if args.listener is not None:
+        conf.insert_json5("listeners", json.dumps(args.listener))
+    # zenoh-net code  --- --- --- --- --- --- --- --- --- --- ---
+
+    # initiate logging
+    zenoh.init_logger()
+
+    print("Openning session...")
+    session = await zenoh.async_open(conf)
+
+    info = await session.info()
+    for key in info:
+        print("{} : {}".format(key, info[key]))
+
+    await session.close()
+
+asyncio.run(main())

--- a/examples/asyncio/z_pub.py
+++ b/examples/asyncio/z_pub.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2017, 2020 ADLINK Technology Inc.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ADLINK zenoh team, <zenoh@adlink-labs.tech>
+
+import asyncio
+import sys
+import time
+import argparse
+import itertools
+import json
+import zenoh
+from zenoh import config
+
+async def main():
+    # --- Command line argument parsing --- --- --- --- --- ---
+    parser = argparse.ArgumentParser(
+        prog='z_pub',
+        description='zenoh pub example')
+    parser.add_argument('--mode', '-m', dest='mode',
+                        choices=['peer', 'client'],
+                        type=str,
+                        help='The zenoh session mode.')
+    parser.add_argument('--peer', '-e', dest='peer',
+                        metavar='LOCATOR',
+                        action='append',
+                        type=str,
+                        help='Peer locators used to initiate the zenoh session.')
+    parser.add_argument('--listener', '-l', dest='listener',
+                        metavar='LOCATOR',
+                        action='append',
+                        type=str,
+                        help='Locators to listen on.')
+    parser.add_argument('--key', '-k', dest='key',
+                        default='/demo/example/zenoh-python-pub',
+                        type=str,
+                        help='The key expression to publish onto.')
+    parser.add_argument('--value', '-v', dest='value',
+                        default='Pub from Python!',
+                        type=str,
+                        help='The value to publish.')
+    parser.add_argument("--iter", dest="iter", type=int, help="How many puts to perform")
+    parser.add_argument('--config', '-c', dest='config',
+                        metavar='FILE',
+                        type=str,
+                        help='A configuration file.')
+
+    args = parser.parse_args()
+    conf = zenoh.config_from_file(args.config) if args.config is not None else zenoh.Config()
+    if args.mode is not None:
+        conf.insert_json5("mode", json.dumps(args.mode))
+    if args.peer is not None:
+        conf.insert_json5("peers", json.dumps(args.peer))
+    if args.listener is not None:
+        conf.insert_json5("listeners", json.dumps(args.listener))
+    key = args.key
+    value = args.value
+
+    # zenoh-net code  --- --- --- --- --- --- --- --- --- --- ---
+
+    # initiate logging
+    zenoh.init_logger()
+
+    print("Openning session...")
+    session = await zenoh.async_open(conf)
+
+    print("Declaring key expression '{}'...".format(key), end='')
+    rid = await session.declare_expr(key)
+    print(" => RId {}".format(rid))
+
+    print("Declaring publication on '{}'...".format(rid))
+    await session.declare_publication(rid)
+
+    for idx in itertools.count() if args.iter is None else range(args.iter):
+        time.sleep(1)
+        buf = "[{:4d}] {}".format(idx, value)
+        print("Putting Data ('{}': '{}')...".format(rid, buf))
+        await session.put(rid, bytes(buf, encoding='utf8'))
+
+    await session.undeclare_publication(rid)
+    await session.undeclare_expr(rid)
+    await session.close()
+
+asyncio.run(main())

--- a/examples/asyncio/z_put.py
+++ b/examples/asyncio/z_put.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2017, 2020 ADLINK Technology Inc.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ADLINK zenoh team, <zenoh@adlink-labs.tech>
+
+import asyncio
+import sys
+import time
+import argparse
+import json
+import zenoh
+from zenoh import config
+
+async def main():
+    # --- Command line argument parsing --- --- --- --- --- ---
+    parser = argparse.ArgumentParser(
+        prog='z_put',
+        description='zenoh put example')
+    parser.add_argument('--mode', '-m', dest='mode',
+                        choices=['peer', 'client'],
+                        type=str,
+                        help='The zenoh session mode.')
+    parser.add_argument('--peer', '-e', dest='peer',
+                        metavar='LOCATOR',
+                        action='append',
+                        type=str,
+                        help='Peer locators used to initiate the zenoh session.')
+    parser.add_argument('--listener', '-l', dest='listener',
+                        metavar='LOCATOR',
+                        action='append',
+                        type=str,
+                        help='Locators to listen on.')
+    parser.add_argument('--key', '-k', dest='key',
+                        default='/demo/example/zenoh-python-put',
+                        type=str,
+                        help='The key expression to write.')
+    parser.add_argument('--value', '-v', dest='value',
+                        default='Put from Python!',
+                        type=str,
+                        help='The value to write.')
+    parser.add_argument('--config', '-c', dest='config',
+                        metavar='FILE',
+                        type=str,
+                        help='A configuration file.')
+
+    args = parser.parse_args()
+    conf = zenoh.config_from_file(args.config) if args.config is not None else zenoh.Config()
+    if args.mode is not None:
+        conf.insert_json5("mode", json.dumps(args.mode))
+    if args.peer is not None:
+        conf.insert_json5("peers", json.dumps(args.peer))
+    if args.listener is not None:
+        conf.insert_json5("listeners", json.dumps(args.listener))
+    key = args.key
+    value = args.value
+
+    # zenoh-net code  --- --- --- --- --- --- --- --- --- --- ---
+
+    # initiate logging
+    zenoh.init_logger()
+
+    print("Openning session...")
+    session = await zenoh.async_open(conf)
+
+    print("Putting Data ('{}': '{}')...".format(key, value))
+    await session.put(key, value)
+
+    await session.close()
+
+asyncio.run(main())

--- a/examples/asyncio/z_scout.py
+++ b/examples/asyncio/z_scout.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2017, 2020 ADLINK Technology Inc.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ADLINK zenoh team, <zenoh@adlink-labs.tech>
+
+import asyncio
+import sys
+import time
+import argparse
+import zenoh
+from zenoh import WhatAmI
+
+async def main():
+    # initiate logging
+    zenoh.init_logger()
+
+    print("Scouting...")
+    hellos = await zenoh.async_scout(WhatAmI.Peer | WhatAmI.Router, 1.0)
+
+    for hello in hellos:
+        print(hello)
+
+asyncio.run(main())

--- a/examples/asyncio/z_sub.py
+++ b/examples/asyncio/z_sub.py
@@ -60,7 +60,7 @@ async def main():
     # zenoh-net code  --- --- --- --- --- --- --- --- --- --- ---
 
 
-    def listener(sample):
+    async def listener(sample):
         time = '(not specified)' if sample.source_info is None or sample.timestamp is None else datetime.fromtimestamp(
             sample.timestamp.time)
         print(">> [Subscriber] Received {} ('{}': '{}')"

--- a/examples/asyncio/z_sub.py
+++ b/examples/asyncio/z_sub.py
@@ -17,7 +17,6 @@ from datetime import datetime
 import argparse
 import json
 import zenoh
-import zenoh.asyncio
 from zenoh import Reliability, SubMode
 
 async def main():
@@ -72,11 +71,11 @@ async def main():
     zenoh.init_logger()
 
     print("Openning session...")
-    session = await zenoh.asyncio.open(conf)
+    session = await zenoh.async_open(conf)
 
     print("Creating Subscriber on '{}'...".format(key))
 
-    sub = session.subscribe(key, listener, reliability=Reliability.Reliable, mode=SubMode.Push)
+    sub = await session.subscribe(key, listener, reliability=Reliability.Reliable, mode=SubMode.Push)
 
     print("Enter 'q' to quit...")
     c = '\0'
@@ -85,8 +84,8 @@ async def main():
         if c == '':
             time.sleep(1)
 
-    sub.close()
-    session.close()
+    await sub.close()
+    await session.close()
 
 
 asyncio.run(main())

--- a/examples/asyncio/z_sub.py
+++ b/examples/asyncio/z_sub.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2017, 2020 ADLINK Technology Inc.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ADLINK zenoh team, <zenoh@adlink-labs.tech>
+
+import asyncio
+import sys
+import time
+from datetime import datetime
+import argparse
+import json
+import zenoh
+import zenoh.asyncio
+from zenoh import Reliability, SubMode
+
+async def main():
+    # --- Command line argument parsing --- --- --- --- --- ---
+    parser = argparse.ArgumentParser(
+        prog='z_sub',
+        description='zenoh sub example')
+    parser.add_argument('--mode', '-m', dest='mode',
+                        choices=['peer', 'client'],
+                        type=str,
+                        help='The zenoh session mode.')
+    parser.add_argument('--peer', '-e', dest='peer',
+                        metavar='LOCATOR',
+                        action='append',
+                        type=str,
+                        help='Peer locators used to initiate the zenoh session.')
+    parser.add_argument('--listener', '-l', dest='listener',
+                        metavar='LOCATOR',
+                        action='append',
+                        type=str,
+                        help='Locators to listen on.')
+    parser.add_argument('--key', '-k', dest='key',
+                        default='/demo/example/**',
+                        type=str,
+                        help='The key expression to subscribe to.')
+    parser.add_argument('--config', '-c', dest='config',
+                        metavar='FILE',
+                        type=str,
+                        help='A configuration file.')
+
+    args = parser.parse_args()
+    conf = zenoh.config_from_file(args.config) if args.config is not None else zenoh.Config()
+    if args.mode is not None:
+        conf.insert_json5("mode", json.dumps(args.mode))
+    if args.peer is not None:
+        conf.insert_json5("peers", json.dumps(args.peer))
+    if args.listener is not None:
+        conf.insert_json5("listeners", json.dumps(args.listener))
+    key = args.key
+
+    # zenoh-net code  --- --- --- --- --- --- --- --- --- --- ---
+
+
+    def listener(sample):
+        time = '(not specified)' if sample.source_info is None or sample.timestamp is None else datetime.fromtimestamp(
+            sample.timestamp.time)
+        print(">> [Subscriber] Received {} ('{}': '{}')"
+            .format(sample.kind, sample.key_expr, sample.payload.decode("utf-8"), time))
+
+
+    # initiate logging
+    zenoh.init_logger()
+
+    print("Openning session...")
+    session = await zenoh.asyncio.open(conf)
+
+    print("Creating Subscriber on '{}'...".format(key))
+
+    sub = session.subscribe(key, listener, reliability=Reliability.Reliable, mode=SubMode.Push)
+
+    print("Enter 'q' to quit...")
+    c = '\0'
+    while c != 'q':
+        c = sys.stdin.read(1)
+        if c == '':
+            time.sleep(1)
+
+    sub.close()
+    session.close()
+
+
+asyncio.run(main())

--- a/examples/z_get.py
+++ b/examples/z_get.py
@@ -82,7 +82,7 @@ print("Openning session...")
 session = zenoh.open(conf)
 
 print("Sending Query '{}'...".format(selector))
-replies = session.get_collect(selector, target=QueryTarget(kind, target))
+replies = session.get(selector, target=QueryTarget(kind, target))
 for reply in replies:
     print(">> Received ('{}': '{}')"
           .format(reply.data.key_expr, reply.data.payload.decode("utf-8")))

--- a/src/async_session.rs
+++ b/src/async_session.rs
@@ -11,14 +11,14 @@
 // Contributors:
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
+use super::async_types::{AsyncQueryable, AsyncSubscriber};
 use super::encoding::Encoding;
 use super::sample_kind::SampleKind;
 use super::types::{
-    zkey_expr_of_pyany, zvalue_of_pyany, CongestionControl, Priority, Query, QueryConsolidation,
-    QueryTarget, Queryable, Reply, Sample, Subscriber, ZnSubOps,
+    zkey_expr_of_pyany, zvalue_of_pyany, CongestionControl, KeyExpr, Period, Priority, Query,
+    QueryConsolidation, QueryTarget, Reliability, Reply, Sample, SubMode, ZnSubOps,
 };
-use crate::types::{KeyExpr, Period, Reliability, SubMode};
-use crate::{to_pyerr, ZError};
+use super::{to_pyerr, ZError};
 use async_std::channel::bounded;
 use async_std::sync::Arc;
 use async_std::task;
@@ -284,7 +284,7 @@ impl AsyncSession {
         })
     }
 
-    /// Create a Subscriber for the given key expression.
+    /// Create a AsyncSubscriber for the given key expression.
     ///
     /// The *key_expr* parameter also accepts the following types that can be converted to a :class:`KeyExpr`:
     ///
@@ -298,7 +298,7 @@ impl AsyncSession {
     /// :type info: SubInfo
     /// :param callback: the subscription callback
     /// :type callback: function(:class:`Sample`)
-    /// :rtype: Subscriber
+    /// :rtype: AsyncSubscriber
     ///
     /// :Examples:
     ///
@@ -409,14 +409,14 @@ impl AsyncSession {
                     }
                 })
             });
-            Ok(Subscriber {
+            Ok(AsyncSubscriber {
                 unregister_tx,
                 loop_handle: Some(loop_handle),
             })
         })
     }
 
-    /// Create a Queryable for the given key expression.
+    /// Create a AsyncQueryable for the given key expression.
     ///
     /// The *key_expr* parameter also accepts the following types that can be converted to a :class:`KeyExpr`:
     ///
@@ -430,7 +430,7 @@ impl AsyncSession {
     /// :type info: int
     /// :param callback: the queryable callback
     /// :type callback: function(:class:`Query`)
-    /// :rtype: Queryable
+    /// :rtype: AsyncQueryable
     ///
     /// :Examples:
     ///
@@ -495,7 +495,7 @@ impl AsyncSession {
                     }
                 })
             });
-            Ok(Queryable {
+            Ok(AsyncQueryable {
                 unregister_tx,
                 loop_handle: Some(loop_handle),
             })

--- a/src/async_session.rs
+++ b/src/async_session.rs
@@ -376,36 +376,46 @@ impl AsyncSession {
             // does any blocking call we do not incour the risk of blocking
             // any of the task resolving futures.
             let loop_handle = task::spawn_blocking(move || {
-                task::block_on(async move {
-                    loop {
-                        select!(
-                            s = static_zn_sub.receiver().next().fuse() => {
-                                // Acquire Python GIL to call the callback
-                                let gil = Python::acquire_gil();
-                                let py = gil.python();
-                                let cb_args = PyTuple::new(py, &[Sample { s: s.unwrap() }]);
-                                if let Err(e) = cb_obj.as_ref(py).call1(cb_args) {
-                                    warn!("Error calling subscriber callback:");
-                                    e.print(py);
-                                }
-                            },
-                            op = unregister_rx.recv().fuse() => {
-                                match op {
-                                    Ok(ZnSubOps::Pull) => {
-                                        if let Err(e) = static_zn_sub.pull().await {
-                                            warn!("Error pulling the subscriber: {}", e);
+                Python::with_gil(|py| {
+                    // Run a Python event loop in this task, to allow coroutines execution within the callback
+                    match pyo3_asyncio::async_std::run(py, async move {
+                        loop {
+                            select!(
+                                    s = static_zn_sub.receiver().next().fuse() => {
+                                        // call the async callback and transform the resulting Python awaitable into a Rust future
+                                        let future = match Python::with_gil(|py| {
+                                            let cb_args = PyTuple::new(py, &[Sample { s: s.unwrap() }]);
+                                            cb_obj.as_ref(py).call1(cb_args).and_then(pyo3_asyncio::async_std::into_future)
+                                        }) {
+                                            Ok(f) => f,
+                                            Err(e) => { warn!("Error calling async queryable callback: {}", e); continue }
+                                        };
+                                        // await the future (by default callbacks are executed in sequence)
+                                        if let Err(e) = future.await {
+                                            warn!("Error suring axecution of async queryable callback: {}", e);
                                         }
                                     },
-                                    Ok(ZnSubOps::Unregister) => {
-                                        if let Err(e) = static_zn_sub.close().await {
-                                            warn!("Error undeclaring subscriber: {}", e);
-                                        }
-                                        return
-                                    },
-                                    _ => return
+                                op = unregister_rx.recv().fuse() => {
+                                    match op {
+                                        Ok(ZnSubOps::Pull) => {
+                                            if let Err(e) = static_zn_sub.pull().await {
+                                                warn!("Error pulling the subscriber: {}", e);
+                                            }
+                                        },
+                                        Ok(ZnSubOps::Unregister) => {
+                                            if let Err(e) = static_zn_sub.close().await {
+                                                warn!("Error undeclaring subscriber: {}", e);
+                                            }
+                                            return Ok(())
+                                        },
+                                        _ => return Ok(())
+                                    }
                                 }
-                            }
-                        )
+                            )
+                        }
+                    }) {
+                        Ok(()) => warn!("Queryable loop running"),
+                        Err(e) => warn!("Failed to start Queryable loop: {}", e),
                     }
                 })
             });

--- a/src/async_types.rs
+++ b/src/async_types.rs
@@ -1,0 +1,81 @@
+//
+// Copyright (c) 2017, 2020 ADLINK Technology Inc.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ADLINK zenoh team, <zenoh@adlink-labs.tech>
+//
+use crate::types::*;
+use async_std::channel::Sender;
+use log::warn;
+use pyo3::prelude::*;
+use pyo3_asyncio::async_std::future_into_py;
+
+/// A subscriber
+#[pyclass]
+pub(crate) struct AsyncSubscriber {
+    pub(crate) unregister_tx: Sender<ZnSubOps>,
+    pub(crate) loop_handle: Option<async_std::task::JoinHandle<()>>,
+}
+
+#[pymethods]
+impl AsyncSubscriber {
+    /// Pull available data for a pull-mode subscriber.
+    fn pull<'p>(&self, py: Python<'p>) -> PyResult<&'p PyAny> {
+        let s = self.unregister_tx.clone();
+        future_into_py(py, async move {
+            if let Err(e) = s.send(ZnSubOps::Pull).await {
+                warn!("Error in Subscriber::pull() : {}", e);
+            }
+            Ok(())
+        })
+    }
+
+    /// Close the subscriber.
+    fn close<'p>(&mut self, py: Python<'p>) -> PyResult<&'p PyAny> {
+        if let Some(handle) = self.loop_handle.take() {
+            let s = self.unregister_tx.clone();
+            future_into_py(py, async move {
+                if let Err(e) = s.send(ZnSubOps::Unregister).await {
+                    warn!("Error in Subscriber::close() : {}", e);
+                }
+                handle.await;
+                Ok(())
+            })
+        } else {
+            future_into_py(py, async move { Ok(()) })
+        }
+    }
+}
+
+/// An entity able to reply to queries.
+#[pyclass]
+pub(crate) struct AsyncQueryable {
+    pub(crate) unregister_tx: Sender<bool>,
+    pub(crate) loop_handle: Option<async_std::task::JoinHandle<()>>,
+}
+
+#[pymethods]
+impl AsyncQueryable {
+    /// Close the queryable.
+    fn close<'p>(&mut self, py: Python<'p>) -> PyResult<&'p PyAny> {
+        if let Some(handle) = self.loop_handle.take() {
+            let s = self.unregister_tx.clone();
+            future_into_py(py, async move {
+                if let Err(e) = s.send(true).await {
+                    warn!("Error in Queryable::close() : {}", e);
+                }
+                handle.await;
+                Ok(())
+            })
+        } else {
+            future_into_py(py, async move { Ok(()) })
+        }
+    }
+}

--- a/src/async_types.rs
+++ b/src/async_types.rs
@@ -17,7 +17,7 @@ use log::warn;
 use pyo3::prelude::*;
 use pyo3_asyncio::async_std::future_into_py;
 
-/// A subscriber
+/// A subscriber to be used with asyncio.
 #[pyclass]
 pub(crate) struct AsyncSubscriber {
     pub(crate) unregister_tx: Sender<ZnSubOps>,
@@ -27,6 +27,8 @@ pub(crate) struct AsyncSubscriber {
 #[pymethods]
 impl AsyncSubscriber {
     /// Pull available data for a pull-mode subscriber.
+    ///
+    /// This method is a **coroutine**.
     fn pull<'p>(&self, py: Python<'p>) -> PyResult<&'p PyAny> {
         let s = self.unregister_tx.clone();
         future_into_py(py, async move {
@@ -38,6 +40,8 @@ impl AsyncSubscriber {
     }
 
     /// Close the subscriber.
+    ///
+    /// This method is a **coroutine**.
     fn close<'p>(&mut self, py: Python<'p>) -> PyResult<&'p PyAny> {
         if let Some(handle) = self.loop_handle.take() {
             let s = self.unregister_tx.clone();
@@ -54,7 +58,7 @@ impl AsyncSubscriber {
     }
 }
 
-/// An entity able to reply to queries.
+/// A queryable to be used with asyncio.
 #[pyclass]
 pub(crate) struct AsyncQueryable {
     pub(crate) unregister_tx: Sender<bool>,
@@ -64,6 +68,8 @@ pub(crate) struct AsyncQueryable {
 #[pymethods]
 impl AsyncQueryable {
     /// Close the queryable.
+    ///
+    /// This method is a **coroutine**.
     fn close<'p>(&mut self, py: Python<'p>) -> PyResult<&'p PyAny> {
         if let Some(handle) = self.loop_handle.take() {
             let s = self.unregister_tx.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,12 +22,14 @@ use zenoh_core::zerror;
 
 pub(crate) mod types;
 pub(crate) use types::*;
-mod async_session;
-use async_session::*;
 mod session;
 use session::*;
+mod async_types;
 mod encoding;
 mod sample_kind;
+use async_types::*;
+mod async_session;
+use async_session::*;
 
 create_exception!(zenoh, ZError, pyo3::exceptions::PyException);
 
@@ -132,6 +134,9 @@ sys.modules['zenoh.queryable'] = queryable
     m.add_class::<Target>()?;
     m.add_class::<Timestamp>()?;
     m.add_class::<WhatAmI>()?;
+    m.add_class::<AsyncSession>()?;
+    m.add_class::<AsyncSubscriber>()?;
+    m.add_class::<AsyncQueryable>()?;
     m.add_wrapped(wrap_pyfunction!(open))?;
     m.add_wrapped(wrap_pyfunction!(async_open))?;
     m.add_wrapped(wrap_pyfunction!(scout))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,12 +330,12 @@ fn scout(whatami: WhatAmI, scout_duration: f64, config: Option<Config>) -> PyRes
 /// >>> asyncio.run(main())
 #[pyfunction]
 #[pyo3(text_signature = "(whatami, scout_duration, config)")]
-fn async_scout<'p>(
+fn async_scout(
     whatami: WhatAmI,
     scout_duration: f64,
     config: Option<Config>,
-    py: Python<'p>,
-) -> PyResult<&'p PyAny> {
+    py: Python,
+) -> PyResult<&PyAny> {
     future_into_py(py, async move {
         let mut result = Vec::<Hello>::new();
         let mut receiver = zenoh::scout(whatami, config.unwrap_or_default().inner)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,7 +248,9 @@ fn open(config: Option<Config>) -> PyResult<Session> {
 #[pyo3(text_signature = "(config)")]
 fn async_open(py: Python, config: Option<Config>) -> PyResult<&PyAny> {
     future_into_py(py, async {
-        let s = zenoh::open(config.unwrap_or_default().inner).await.map_err(to_pyerr)?;
+        let s = zenoh::open(config.unwrap_or_default().inner)
+            .await
+            .map_err(to_pyerr)?;
         Ok(AsyncSession::new(s))
     })
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -30,7 +30,7 @@ use pyo3::types::{IntoPyDict, PyDict, PyList, PyTuple};
 use std::collections::HashMap;
 use zenoh::prelude::{ExprId, KeyExpr as ZKeyExpr, ZFuture, ZInt};
 
-/// A zenoh-net session.
+/// A zenoh session.
 #[pyclass]
 pub struct Session {
     s: Option<zenoh::Session>,
@@ -38,20 +38,20 @@ pub struct Session {
 
 #[pymethods]
 impl Session {
-    /// Close the zenoh-net Session.
+    /// Close the zenoh Session.
     pub fn close(&mut self) -> PyResult<()> {
         let s = self.take()?;
         s.close().wait().map_err(to_pyerr)
     }
 
-    /// Get informations about the zenoh-net Session.
+    /// Get informations about the zenoh Session.
     ///
     /// :rtype: dict {str: str}
     ///
     /// :Example:
     ///
     /// >>> import zenoh
-    /// >>> s = zenoh.open({})
+    /// >>> s = zenoh.open()
     /// >>> info = s.info()
     /// >>> for key in info:
     /// >>>    print("{} : {}".format(key, info[key]))
@@ -76,7 +76,7 @@ impl Session {
     /// * **(int, str)** for a mapped key expression with suffix
     ///
     /// :param key_expr: The key expression matching resources to write
-    /// :type key_expr: KeyExpr
+    /// :type key_expr: :class:`KeyExpr`
     /// :param value: The value to write
     /// :type value: Value
     /// :param encoding: The encoding of the value
@@ -84,12 +84,12 @@ impl Session {
     /// :param kind: The kind of value
     /// :type kind: int, optional
     /// :param congestion_control: The value for the congestion control
-    /// :type congestion_control: CongestionControl, optional
+    /// :type congestion_control: :class:`CongestionControl`, optional
     ///
     /// :Examples:
     ///
     /// >>> import zenoh
-    /// >>> s = zenoh.open({})
+    /// >>> s = zenoh.open()
     /// >>> s.put('/key/expression', bytes('value', encoding='utf8'))
     #[pyo3(text_signature = "(self, key_expr, value, **kwargs)")]
     #[args(kwargs = "**")]
@@ -135,14 +135,14 @@ impl Session {
     /// * **(int, str)** for a mapped key expression with suffix
     ///
     /// :param key_expr: The key expression matching resources to delete
-    /// :type key_expr: KeyExpr
+    /// :type key_expr: :class:`KeyExpr`
     /// :param congestion_control: The value for the congestion control
-    /// :type congestion_control: CongestionControl, optional
+    /// :type congestion_control: :class:`CongestionControl`, optional
     ///
     /// :Examples:
     ///
     /// >>> import zenoh
-    /// >>> s = zenoh.open({})
+    /// >>> s = zenoh.open()
     /// >>> s.delete('/key/expression')
     #[pyo3(text_signature = "(self, key_expr, **kwargs)")]
     #[args(kwargs = "**")]
@@ -178,13 +178,13 @@ impl Session {
     /// * **(int, str)** for a mapped key expression with suffix
     ///
     /// :param key_expr: The key expression to map to a numerical Id
-    /// :type key_expr: KeyExpr
-    /// :rtype: int
+    /// :type key_expr: :class:`KeyExpr`
+    /// :rtype: :class:`ExprId`
     ///
     /// :Examples:
     ///
     /// >>> import zenoh
-    /// >>> s = zenoh.open({})
+    /// >>> s = zenoh.open()
     /// >>> rid = s.declare_expr('/key/expression')
     #[pyo3(text_signature = "(self, key_expr)")]
     pub fn declare_expr(&self, key_expr: &PyAny) -> PyResult<ExprId> {
@@ -197,12 +197,12 @@ impl Session {
     /// with :meth:`declare_expr`.
     ///
     /// :param rid: The numerical Id to unmap
-    /// :type rid: ExprId
+    /// :type rid: :class:`ExprId`
     ///
     /// :Examples:
     ///
     /// >>> import zenoh
-    /// >>> s = zenoh.open({})
+    /// >>> s = zenoh.open()
     /// >>> rid = s.declare_expr('/key/expression')
     /// >>> s.undeclare_expr(rid)
     #[pyo3(text_signature = "(self, rid)")]
@@ -223,12 +223,12 @@ impl Session {
     /// * **(int, str)** for a mapped key expression with suffix
     ///
     /// :param key_expr: The key expression to publish
-    /// :type key_expr: KeyExpr
+    /// :type key_expr: :class:`KeyExpr`
     ///
     /// :Examples:
     ///
     /// >>> import zenoh
-    /// >>> s = zenoh.open({})
+    /// >>> s = zenoh.open()
     /// >>> rid = s.declare_publication('/key/expression')
     /// >>> s.put('/key/expression', bytes('value', encoding='utf8'))
     #[pyo3(text_signature = "(self, key_expr)")]
@@ -256,19 +256,24 @@ impl Session {
     ///
     /// :param key_expr: The key expression to subscribe
     /// :type key_expr: KeyExpr
-    /// :param info: The :class:`SubInfo` to configure the subscription
-    /// :type info: SubInfo
     /// :param callback: the subscription callback
     /// :type callback: function(:class:`Sample`)
-    /// :rtype: Subscriber
+    /// :param reliability: the subscription reliability
+    /// :type reliability: :class:`Reliability`, optional
+    /// :param mode: the subscription mode
+    /// :type mode: :class:`SubMode`, optional
+    /// :param period: the subscription period
+    /// :type period: :class:`Period`, optional
+    /// :param local: if the subscription is local only
+    /// :type local: bool
+    /// :rtype: :class:`Subscriber`
     ///
     /// :Examples:
     ///
     /// >>> import zenoh, time
-    /// >>> from zenoh import SubInfo, Reliability, SubMode
+    /// >>> from zenoh import Reliability, SubMode
     /// >>>
-    /// >>> s = zenoh.open({})
-    /// >>> sub_info = SubInfo(Reliability.Reliable, SubMode.Push)
+    /// >>> s = zenoh.open()
     /// >>> sub = s.subscribe('/key/expression',
     /// ...     lambda sample: print("Received : {}".format(sample)),
     /// ...     reliability=Reliability.Reliable,
@@ -367,12 +372,12 @@ impl Session {
     /// * **(int, str)** for a mapped key expression with suffix
     ///
     /// :param key_expr: The key expression the Queryable will reply to
-    /// :type key_expr: KeyExpr
+    /// :type key_expr: :class:`KeyExpr`
     /// :param info: The kind of Queryable
     /// :type info: int
     /// :param callback: the queryable callback
     /// :type callback: function(:class:`Query`)
-    /// :rtype: Queryable
+    /// :rtype: :class:`Queryable`
     ///
     /// :Examples:
     ///
@@ -382,7 +387,7 @@ impl Session {
     /// ...     print("Received : {}".format(query))
     /// ...     query.reply(Sample('/key/expression', bytes('value', encoding='utf8')))
     /// >>>
-    /// >>> s = zenoh.open({})
+    /// >>> s = zenoh.open()
     /// >>> q = s.queryable('/key/expression', queryable.EVAL, callback)
     /// >>> time.sleep(60)
     #[pyo3(text_signature = "(self, key_expr, kind, callback)")]
@@ -449,9 +454,9 @@ impl Session {
     /// :param selector: The selection of resources to query
     /// :type selector: str
     /// :param target: The kind of queryables that should be target of this query
-    /// :type target: QueryTarget, optional
+    /// :type target: :class:`QueryTarget`, optional
     /// :param consolidation: The kind of consolidation that should be applied on replies
-    /// :type consolidation: QueryConsolidation, optional
+    /// :type consolidation: :class:`QueryConsolidation`, optional
     /// :rtype: [:class:`Reply`]
     ///
     /// :Examples:
@@ -523,13 +528,13 @@ impl Session {
     fn as_ref(&self) -> PyResult<&zenoh::Session> {
         self.s
             .as_ref()
-            .ok_or_else(|| PyErr::new::<ZError, _>("zenoh-net session was closed"))
+            .ok_or_else(|| PyErr::new::<ZError, _>("zenoh session was closed"))
     }
 
     #[inline]
     fn take(&mut self) -> PyResult<zenoh::Session> {
         self.s
             .take()
-            .ok_or_else(|| PyErr::new::<ZError, _>("zenoh-net session was closed"))
+            .ok_or_else(|| PyErr::new::<ZError, _>("zenoh session was closed"))
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -14,11 +14,11 @@
 use super::encoding::Encoding;
 use super::sample_kind::SampleKind;
 use super::types::{
-    zkey_expr_of_pyany, zvalue_of_pyany, CongestionControl, Priority, Query, QueryConsolidation,
-    QueryTarget, Queryable, Reply, Sample, Subscriber, ZnSubOps,
+    zkey_expr_of_pyany, zvalue_of_pyany, CongestionControl, KeyExpr, Period, Priority, Query,
+    QueryConsolidation, QueryTarget, Queryable, Reliability, Reply, Sample, SubMode, Subscriber,
+    ZnSubOps,
 };
-use crate::types::{KeyExpr, Period, Reliability, SubMode};
-use crate::{to_pyerr, ZError};
+use super::{to_pyerr, ZError};
 use async_std::channel::bounded;
 use async_std::task;
 use futures::prelude::*;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1015,8 +1015,8 @@ impl Query {
     ///
     /// :type: str
     #[getter]
-    fn value_selector(&self) -> &str {
-        self.q.selector().value_selector
+    fn value_selector(&self) -> String {
+        self.q.selector().value_selector.to_string()
     }
 
     /// Send a reply to the query


### PR DESCRIPTION
This PR adds an `AsyncSession` class defining all its methods (put, get, subscribe...)  as [asyncio](https://docs.python.org/3/library/asyncio.html) coroutines.
An `AsyncSession` object is returned calling the `zenoh.async_open()` coroutine.

Example of usage for a `put()`:
```python
import asyncio, zenoh
async def main():
   s = await zenoh.async_open()
   await s.put('/demo/example/zenoh-python-put', bytes('Put from asyncio Python!', encoding='utf8'))

asyncio.run(main())
```

Example of usage for a `subscribe()`:
```python
import asyncio, zenoh
from zenoh import Reliability, SubMode

async def callback(sample):
   print("Received : {}".format(sample))

async def main():
   s = await zenoh.async_open()
   sub = await s.subscribe('/demo/example/**', callback,
      reliability=Reliability.Reliable,
      mode=SubMode.Push)
   await asyncio.sleep(60)

asyncio.run(main())
```

More examples of usage in `examples/asyncio/`

This PR fixes #34.