### PR TITLE
CI: remove builds with Python 3.7 and 3.8, add build with Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.9, 3.10]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The recent version 1.3.0 of [setuptools_rust](https://github.com/PyO3/setuptools-rust) relies on setuptools 58 and leads to troubles when used with Python <= 3.8 (see https://github.com/eclipse-zenoh/zenoh-python/runs/6285114030?check_suite_focus=true).

Anyway, zenoh-python build works fine with Python 3.9 and 3.10. And it's Release workflow targets CPython 3.8. See: https://github.com/eclipse-zenoh/zenoh-python/blob/5cf95e6899e84fd0a8540b8befd526babb3763f6/.github/workflows/release.yml#L84

Thus we can remove CI builds with Python <= 3.8