### PR TITLE
Update example

### DIFF
--- a/examples/z_get.py
+++ b/examples/z_get.py
@@ -55,7 +55,8 @@ parser.add_argument('--config', '-c', dest='config',
                     help='A configuration file.')
 
 args = parser.parse_args()
-conf = zenoh.Config.from_file(args.config) if args.config is not None else zenoh.Config()
+conf = zenoh.Config.from_file(
+    args.config) if args.config is not None else zenoh.Config()
 if args.mode is not None:
     conf.insert_json5(zenoh.config.MODE_KEY, json.dumps(args.mode))
 if args.connect is not None:
@@ -67,7 +68,7 @@ target = {
     'ALL': QueryTarget.ALL(),
     'BEST_MATCHING': QueryTarget.BEST_MATCHING(),
     'ALL_COMPLETE': QueryTarget.ALL_COMPLETE(),
-    }.get(args.target)
+}.get(args.target)
 
 # Zenoh code  --- --- --- --- --- --- --- --- --- --- ---
 
@@ -78,14 +79,14 @@ print("Opening session...")
 session = zenoh.open(conf)
 
 print("Sending Query '{}'...".format(selector))
-replies = session.get(selector, zenoh.ListCollector(), target=target, value=args.value)
-for reply in replies():
+replies = session.get(selector, zenoh.Queue(), target=target, value=args.value)
+for reply in replies.receiver:
     try:
         print(">> Received ('{}': '{}')"
-            .format(reply.ok.key_expr, reply.ok.payload.decode("utf-8")))
+              .format(reply.ok.key_expr, reply.ok.payload.decode("utf-8")))
     except:
         print(">> Received (ERROR: '{}')"
-            .format(reply.err.payload.decode("utf-8")))
+              .format(reply.err.payload.decode("utf-8")))
 
 
 session.close()


### PR DESCRIPTION
Use `zenoh.Queue` for get instead of `zenoh.ListCollector` as default as it is a safest option in terms of memory usage and congestion control.