### PR TITLE
Make callbacks run concurrently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,6 +456,7 @@ version = "0.7.0-rc"
 dependencies = [
  "async-std",
  "env_logger",
+ "flume",
  "form_urlencoded",
  "futures",
  "json5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ complete_n = ["zenoh/complete_n"]
 [dependencies]
 async-std = "=1.12.0"
 env_logger = "0.10.0"
+flume = "0.10.14"
 form_urlencoded = "1.1.0"
 futures = "0.3.25"
 json5 = "0.4.1"
@@ -44,7 +45,9 @@ pyo3 = { version = "0.17.3", features = ["extension-module", "abi3-py37"] }
 serde_json = "1.0.89"
 uhlc = { git = "https://github.com/atolab/uhlc-rs.git", default-features = false } # TODO: Using github source until the no_std update gets released on crates.io
 validated_struct = "2.1.0"
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master", features = [ "unstable" ] }
+zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master", features = [
+    "unstable",
+] }
 zenoh-buffers = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master" }
 zenoh-cfg-properties = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master" }
-zenoh-core =  { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master" }
+zenoh-core = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master" }

--- a/examples/z_queryable.py
+++ b/examples/z_queryable.py
@@ -91,5 +91,4 @@ while c != 'q':
         time.sleep(1)
 
 queryable.undeclare()
-print("UNDECLARED")
 session.close()

--- a/examples/z_queryable.py
+++ b/examples/z_queryable.py
@@ -55,8 +55,7 @@ parser.add_argument('--config', '-c', dest='config',
                     help='A configuration file.')
 
 args = parser.parse_args()
-conf = zenoh.Config.from_file(
-    args.config) if args.config is not None else zenoh.Config()
+conf = zenoh.Config.from_file(args.config) if args.config is not None else zenoh.Config()
 if args.mode is not None:
     conf.insert_json5(zenoh.config.MODE_KEY, json.dumps(args.mode))
 if args.connect is not None:
@@ -92,4 +91,5 @@ while c != 'q':
         time.sleep(1)
 
 queryable.undeclare()
+print("UNDECLARED")
 session.close()

--- a/examples/z_sub_thr.py
+++ b/examples/z_sub_thr.py
@@ -91,7 +91,11 @@ zenoh.init_logger()
 
 session = zenoh.open(conf)
 
-sub = session.declare_subscriber("test/thr", (listener, report), reliability=Reliability.RELIABLE())
+# By explicitly constructing the `Closure`, the `Queue` that's normally inserted between the callback and zenoh is removed.
+# Only do this if:
+#   a) your callback runs faster than the minimum expected delay between two samples
+#   b) you want your callback to apply backpressure on the publishers
+sub = session.declare_subscriber("test/thr", zenoh.Closure((listener, report)), reliability=Reliability.RELIABLE())
 
 print("Enter 'q' to quit...")
 c = '\0'

--- a/examples/z_sub_thr.py
+++ b/examples/z_sub_thr.py
@@ -92,9 +92,7 @@ zenoh.init_logger()
 session = zenoh.open(conf)
 
 # By explicitly constructing the `Closure`, the `Queue` that's normally inserted between the callback and zenoh is removed.
-# Only do this if:
-#   a) your callback runs faster than the minimum expected delay between two samples
-#   b) you want your callback to apply backpressure on the publishers
+# Only do this if your callback runs faster than the minimum expected delay between two samples.
 sub = session.declare_subscriber("test/thr", zenoh.Closure((listener, report)), reliability=Reliability.RELIABLE())
 
 print("Enter 'q' to quit...")

--- a/src/closures.rs
+++ b/src/closures.rs
@@ -108,8 +108,11 @@ pub struct _Queue {
 #[pymethods]
 impl _Queue {
     #[new]
-    pub fn pynew() -> Self {
-        let (send, recv) = flume::unbounded();
+    pub fn pynew(bound: Option<usize>) -> Self {
+        let (send, recv) = match bound {
+            None => flume::unbounded(),
+            Some(bound) => flume::bounded(bound),
+        };
         Self {
             send: Some(send),
             recv,

--- a/src/closures.rs
+++ b/src/closures.rs
@@ -136,26 +136,23 @@ impl _Queue {
         }
     }
     pub fn get(&self, timeout: Option<f32>, py: Python<'_>) -> PyResult<PyObject> {
-        Python::allow_threads(py, || {
-            let v = match timeout {
-                None => match self.recv.recv() {
-                    Ok(value) => Ok(value),
-                    Err(_) => Err(pyo3::exceptions::PyStopIteration::new_err(())),
-                },
-                Some(secs) => match self
-                    .recv
-                    .recv_timeout(std::time::Duration::from_secs_f32(secs))
-                {
-                    Ok(value) => Ok(value),
-                    Err(flume::RecvTimeoutError::Timeout) => {
-                        Err(pyo3::exceptions::PyTimeoutError::new_err(()))
-                    }
-                    Err(flume::RecvTimeoutError::Disconnected) => {
-                        Err(pyo3::exceptions::PyStopIteration::new_err(()))
-                    }
-                },
-            };
-            v
+        Python::allow_threads(py, || match timeout {
+            None => match self.recv.recv() {
+                Ok(value) => Ok(value),
+                Err(_) => Err(pyo3::exceptions::PyStopIteration::new_err(())),
+            },
+            Some(secs) => match self
+                .recv
+                .recv_timeout(std::time::Duration::from_secs_f32(secs))
+            {
+                Ok(value) => Ok(value),
+                Err(flume::RecvTimeoutError::Timeout) => {
+                    Err(pyo3::exceptions::PyTimeoutError::new_err(()))
+                }
+                Err(flume::RecvTimeoutError::Disconnected) => {
+                    Err(pyo3::exceptions::PyStopIteration::new_err(()))
+                }
+            },
         })
     }
     pub fn get_remaining(&self, timeout: Option<f32>, py: Python<'_>) -> PyResult<Py<PyList>> {

--- a/src/closures.rs
+++ b/src/closures.rs
@@ -13,7 +13,10 @@
 //
 use std::{convert::TryFrom, sync::Arc};
 
-use pyo3::{prelude::*, types::PyTuple};
+use pyo3::{
+    prelude::*,
+    types::{PyList, PyTuple},
+};
 use zenoh::prelude::IntoCallbackReceiverPair;
 
 trait CallbackUnwrap {
@@ -94,5 +97,81 @@ where
             }),
             (),
         )
+    }
+}
+
+#[pyclass(subclass)]
+pub struct _Queue {
+    send: Option<flume::Sender<PyObject>>,
+    recv: flume::Receiver<PyObject>,
+}
+#[pymethods]
+impl _Queue {
+    #[new]
+    pub fn pynew() -> Self {
+        let (send, recv) = flume::unbounded();
+        Self {
+            send: Some(send),
+            recv,
+        }
+    }
+    pub fn close(&mut self) {
+        self.send = None;
+    }
+    pub fn put(&self, value: PyObject) -> PyResult<()> {
+        match &self.send {
+            None => Err(pyo3::exceptions::PyBrokenPipeError::new_err(
+                "Attempted to put on closed Queue",
+            )),
+            Some(send) => {
+                send.send(value).unwrap();
+                Ok(())
+            }
+        }
+    }
+    pub fn get(&self, timeout: Option<f32>) -> PyResult<PyObject> {
+        match timeout {
+            None => match self.recv.recv() {
+                Ok(value) => Ok(value),
+                Err(_) => Err(pyo3::exceptions::PyStopIteration::new_err(())),
+            },
+            Some(secs) => match self
+                .recv
+                .recv_timeout(std::time::Duration::from_secs_f32(secs))
+            {
+                Ok(value) => Ok(value),
+                Err(flume::RecvTimeoutError::Timeout) => {
+                    Err(pyo3::exceptions::PyTimeoutError::new_err(()))
+                }
+                Err(flume::RecvTimeoutError::Disconnected) => {
+                    Err(pyo3::exceptions::PyStopIteration::new_err(()))
+                }
+            },
+        }
+    }
+    pub fn get_remaining(&self, timeout: Option<f32>) -> PyResult<Py<PyList>> {
+        let vec = match timeout {
+            None => self.recv.iter().collect::<Vec<_>>(),
+            Some(secs) => {
+                let deadline = std::time::Instant::now() + std::time::Duration::from_secs_f32(secs);
+                let mut vec = Vec::new();
+                loop {
+                    match self.recv.recv_deadline(deadline) {
+                        Ok(v) => vec.push(v),
+                        Err(flume::RecvTimeoutError::Disconnected) => break,
+                        Err(flume::RecvTimeoutError::Timeout) => {
+                            let list: Py<PyList> =
+                                Python::with_gil(|py| PyList::new(py, vec).into_py(py));
+                            return Err(pyo3::exceptions::PyTimeoutError::new_err((list,)));
+                        }
+                    }
+                }
+                vec
+            }
+        };
+        Ok(Python::with_gil(|py| PyList::new(py, vec).into_py(py)))
+    }
+    pub fn is_closed(&self) -> bool {
+        self.send.is_none()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ impl<K: ToPyObject> PyExtract<K> for PyDict {
 #[pymodule]
 fn zenoh(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<config::_Config>()?;
+    m.add_class::<closures::_Queue>()?;
     m.add_class::<keyexpr::_KeyExpr>()?;
     m.add_class::<keyexpr::_Selector>()?;
     m.add_class::<session::_Session>()?;

--- a/zenoh/closures.py
+++ b/zenoh/closures.py
@@ -17,6 +17,8 @@ from threading import Condition, Thread
 from collections import deque
 import time
 
+from .zenoh import _Queue
+
 In = TypeVar("In")
 Out = TypeVar("Out")
 Receiver = TypeVar("Receiver")

--- a/zenoh/closures.py
+++ b/zenoh/closures.py
@@ -178,7 +178,7 @@ class ListCollector(IHandler[In, None, Callable[[],List[In]]], Generic[In]):
 
 class Queue(IHandler[In, None, 'Queue'], Generic[In]):
     """
-    A simple single-producer, single-consumer queue implementation.
+    A binding for a Rust multi-producer, single-consumer queue implementation.
 
     When used as a handler, it provides itself as the receiver, and will provide a
     callback that appends elements to the queue.

--- a/zenoh/closures.py
+++ b/zenoh/closures.py
@@ -201,6 +201,8 @@ class Queue(IHandler[In, None, 'Queue'], Generic[In]):
     def put(self, value):
         """
         Puts one element on the queue.
+
+        Raises a `PyBrokenPipeError` if the Queue has been closed.
         """
         self._inner_.put(value)
 
@@ -209,7 +211,8 @@ class Queue(IHandler[In, None, 'Queue'], Generic[In]):
         """
         Gets one element from the queue.
 
-        Raises a `StopIteration` exception if the queue was closed before the timeout ran out.
+        Raises a `StopIteration` exception if the queue was closed before the timeout ran out,
+        this allows using the Queue as an iterator in for-loops.
         Raises a `TimeoutError` if the timeout ran out.
         """
         self._inner_.get(timeout)

--- a/zenoh/closures.py
+++ b/zenoh/closures.py
@@ -182,9 +182,11 @@ class Queue(IHandler[In, None, 'Queue'], Generic[In]):
 
     When used as a handler, it provides itself as the receiver, and will provide a
     callback that appends elements to the queue.
+
+    Can be bounded by passing a maximum size as `bound`.
     """
-    def __init__(self):
-        self._inner_ = _Queue()
+    def __init__(self, bound: int = None):
+        self._inner_ = _Queue(bound)
     
     @property
     def closure(self) -> IClosure[In, None]:

--- a/zenoh/closures.py
+++ b/zenoh/closures.py
@@ -96,7 +96,7 @@ class Closure(IClosure, Generic[In, Out]):
         else:
             adapted = _call_
         if prevent_direct_calls:
-            queue = Queue()
+            queue = Queue(128)
             def readqueue():
                 for x in queue:
                     adapted(*x)
@@ -135,7 +135,7 @@ class Handler(IHandler, Generic[In, Out, Receiver]):
                 self._closure_ = input
         else:
             self._closure_ = input
-        self._closure_ = Closure(self._closure_, type_adaptor, False and not isinstance(self._closure_, Closure))
+        self._closure_ = Closure(self._closure_, type_adaptor, not isinstance(self._closure_, Closure))
 
     @property
     def closure(self) -> IClosure[In, Out]:
@@ -206,7 +206,7 @@ class Queue(IHandler[In, None, 'Queue'], Generic[In]):
 
         Raises a `PyBrokenPipeError` if the Queue has been closed.
         """
-        self._inner_.put(value)
+        return self._inner_.put(value)
 
 
     def get(self, timeout: float = None):
@@ -217,10 +217,10 @@ class Queue(IHandler[In, None, 'Queue'], Generic[In]):
         this allows using the Queue as an iterator in for-loops.
         Raises a `TimeoutError` if the timeout ran out.
         """
-        self._inner_.get(timeout)
+        return self._inner_.get(timeout)
     
     def close(self):
-        self._inner_.close()
+        return self._inner_.close()
     
     def get_remaining(self, timeout: float = None) -> List[In]:
         """
@@ -230,7 +230,7 @@ class Queue(IHandler[In, None, 'Queue'], Generic[In]):
         Raises a `TimeoutError` if the timeout in seconds provided was exceeded before closing,
         whose `args[0]` will contain the elements that were collected before timing out.
         """
-        self._inner_.get_remaining()
+        return self._inner_.get_remaining()
 
     def __iter__(self):
         return self


### PR DESCRIPTION
Callbacks now start a PyThread upon receiving a value to avoid delaying message handover. Manually constructed zenoh.Closures may opt out of this behaviour.