### PR TITLE
Extend the triggering rules of CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: ["**"]
   pull_request:
-    branches: [master]
+    branches: ["**"]
   schedule:
     - cron: "0 6 * * 1-5"
   workflow_dispatch:


### PR DESCRIPTION
Wake up CI runners when branches and pull requests are updated. So that the rule is aligned to the one used in zenoh and zenoh-c repos.