### PR TITLE
Sync `Cargo.lock` and/or `rust-toolchain.toml` with Zenoh's

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2682,7 +2682,7 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 [[package]]
 name = "zenoh"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#5ee57d9503d0867b4511b9ce57f4a3d8aa3a1ce8"
 dependencies = [
  "async-global-executor",
  "async-std",
@@ -2730,7 +2730,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#5ee57d9503d0867b4511b9ce57f4a3d8aa3a1ce8"
 dependencies = [
  "zenoh-collections",
 ]
@@ -2738,7 +2738,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#5ee57d9503d0867b4511b9ce57f4a3d8aa3a1ce8"
 dependencies = [
  "log",
  "serde",
@@ -2750,12 +2750,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#5ee57d9503d0867b4511b9ce57f4a3d8aa3a1ce8"
 
 [[package]]
 name = "zenoh-config"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#5ee57d9503d0867b4511b9ce57f4a3d8aa3a1ce8"
 dependencies = [
  "flume",
  "json5",
@@ -2774,7 +2774,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#5ee57d9503d0867b4511b9ce57f4a3d8aa3a1ce8"
 dependencies = [
  "async-std",
  "lazy_static",
@@ -2784,7 +2784,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#5ee57d9503d0867b4511b9ce57f4a3d8aa3a1ce8"
 dependencies = [
  "aes",
  "hmac",
@@ -2797,7 +2797,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#5ee57d9503d0867b4511b9ce57f4a3d8aa3a1ce8"
 dependencies = [
  "hashbrown 0.14.0",
  "keyed-set",
@@ -2811,7 +2811,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#5ee57d9503d0867b4511b9ce57f4a3d8aa3a1ce8"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2830,7 +2830,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#5ee57d9503d0867b4511b9ce57f4a3d8aa3a1ce8"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2847,7 +2847,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#5ee57d9503d0867b4511b9ce57f4a3d8aa3a1ce8"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -2873,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#5ee57d9503d0867b4511b9ce57f4a3d8aa3a1ce8"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2889,7 +2889,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#5ee57d9503d0867b4511b9ce57f4a3d8aa3a1ce8"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -2914,7 +2914,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#5ee57d9503d0867b4511b9ce57f4a3d8aa3a1ce8"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2933,7 +2933,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#5ee57d9503d0867b4511b9ce57f4a3d8aa3a1ce8"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2951,7 +2951,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#5ee57d9503d0867b4511b9ce57f4a3d8aa3a1ce8"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2971,7 +2971,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#5ee57d9503d0867b4511b9ce57f4a3d8aa3a1ce8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2984,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#5ee57d9503d0867b4511b9ce57f4a3d8aa3a1ce8"
 dependencies = [
  "libloading",
  "log",
@@ -2997,7 +2997,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#5ee57d9503d0867b4511b9ce57f4a3d8aa3a1ce8"
 dependencies = [
  "const_format",
  "hex",
@@ -3033,7 +3033,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#5ee57d9503d0867b4511b9ce57f4a3d8aa3a1ce8"
 dependencies = [
  "anyhow",
 ]
@@ -3041,7 +3041,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#5ee57d9503d0867b4511b9ce57f4a3d8aa3a1ce8"
 dependencies = [
  "async-std",
  "event-listener",
@@ -3056,7 +3056,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#5ee57d9503d0867b4511b9ce57f4a3d8aa3a1ce8"
 dependencies = [
  "async-executor",
  "async-global-executor",
@@ -3087,7 +3087,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#c0ebfff664dd925e9e16d148239eba1ade0ade06"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#5ee57d9503d0867b4511b9ce57f4a3d8aa3a1ce8"
 dependencies = [
  "async-std",
  "async-trait",


### PR DESCRIPTION
Automated synchronization of Cargo.lock and/or rust-toolchain.toml with Zenoh. This is necessary to ensure plugin ABI compatibility.