### PR TITLE
Fix missing Rust toolchain in linux-armv6 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust toolchain
-        run: rustup show
+        run: rustup target add arm-unknown-linux-gnueabihf
       - name: install cross toolchain
         run: |
           brew tap messense/macos-cross-toolchains


### PR DESCRIPTION
In #115 I replaced the `actions-rs/toolchain` with `rustup show` which doesn't install the required target toolchain, because of this the Release workflow is failling on `linux-armv6`. Please note that there is no need to run `rustup show` as installing a target implies installing the toolchain.