### PR TITLE
Sync `Cargo.lock` and/or `rust-toolchain.toml` with Zenoh's

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
 dependencies = [
  "concurrent-queue",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-core",
 ]
 
@@ -191,7 +191,7 @@ version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
 dependencies = [
- "event-listener",
+ "event-listener 2.5.3",
 ]
 
 [[package]]
@@ -205,7 +205,7 @@ dependencies = [
  "autocfg",
  "blocking",
  "cfg-if",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-lite",
  "rustix 0.37.25",
  "signal-hook",
@@ -617,6 +617,17 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "770d968249b5d99410d61f5bf89057f3199a077a04d087092f58e7d10692baae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fastrand"
@@ -1258,9 +1269,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
-version = "3.9.1"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a54938017eacd63036332b4ae5c8a49fc8c0c1d6d629893057e4f13609edd06"
+checksum = "536900a8093134cf9ccf00a27deb3532421099e958d9dd431135d0c7543ca1e8"
 dependencies = [
  "num-traits",
 ]
@@ -1616,10 +1627,10 @@ checksum = "e13f81c9a9d574310b8351f8666f5a93ac3b0069c45c28ad52c10291389a7cf9"
 dependencies = [
  "bytes",
  "rand",
- "ring",
+ "ring 0.16.20",
  "rustc-hash",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "slab",
  "thiserror",
  "tinyvec",
@@ -1746,9 +1757,23 @@ dependencies = [
  "libc",
  "once_cell",
  "spin 0.5.2",
- "untrusted",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684d5e6e18f669ccebf64a92236bb7db9a34f07be010e3627368182027180866"
+dependencies = [
+ "cc",
+ "getrandom",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1838,8 +1863,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
- "ring",
- "rustls-webpki",
+ "ring 0.16.20",
+ "rustls-webpki 0.101.5",
  "sct",
 ]
 
@@ -1850,7 +1875,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.3",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.0.0",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
@@ -1865,13 +1903,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
+dependencies = [
+ "base64",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb0a1f9b9efec70d32e6d6aa3e58ebd88c3754ec98dfe9145c63cf54cc829b83"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45a27e3b59326c16e23d30aeb7a36a24cc0d29e71d68ff611cdfb4a01d013bed"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2635c8bc2b88d367767c5de8ea1d8db9af3f6219eba28442242d9ab81d1b89"
+dependencies = [
+ "ring 0.17.6",
+ "rustls-pki-types",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -1925,8 +1990,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -2438,6 +2503,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "unzip-n"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2612,9 +2683,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
+checksum = "0de2cfda980f21be5a7ed2eadb3e6fe074d56022bea2cdeb1a62eb220fc04188"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "winapi"
@@ -2782,7 +2856,7 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 [[package]]
 name = "zenoh"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#eb60dd09b6c67ea1d1d0044ff6531d2e6821d4bf"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#e3a6c34961afe2fea9d0835a11548cc2500c0dcf"
 dependencies = [
  "async-global-executor",
  "async-std",
@@ -2790,7 +2864,7 @@ dependencies = [
  "base64",
  "const_format",
  "env_logger",
- "event-listener",
+ "event-listener 4.0.0",
  "flume",
  "form_urlencoded",
  "futures",
@@ -2830,7 +2904,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#eb60dd09b6c67ea1d1d0044ff6531d2e6821d4bf"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#e3a6c34961afe2fea9d0835a11548cc2500c0dcf"
 dependencies = [
  "zenoh-collections",
 ]
@@ -2838,7 +2912,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#eb60dd09b6c67ea1d1d0044ff6531d2e6821d4bf"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#e3a6c34961afe2fea9d0835a11548cc2500c0dcf"
 dependencies = [
  "log",
  "serde",
@@ -2850,12 +2924,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#eb60dd09b6c67ea1d1d0044ff6531d2e6821d4bf"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#e3a6c34961afe2fea9d0835a11548cc2500c0dcf"
 
 [[package]]
 name = "zenoh-config"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#eb60dd09b6c67ea1d1d0044ff6531d2e6821d4bf"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#e3a6c34961afe2fea9d0835a11548cc2500c0dcf"
 dependencies = [
  "flume",
  "json5",
@@ -2874,7 +2948,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#eb60dd09b6c67ea1d1d0044ff6531d2e6821d4bf"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#e3a6c34961afe2fea9d0835a11548cc2500c0dcf"
 dependencies = [
  "async-std",
  "lazy_static",
@@ -2884,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#eb60dd09b6c67ea1d1d0044ff6531d2e6821d4bf"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#e3a6c34961afe2fea9d0835a11548cc2500c0dcf"
 dependencies = [
  "aes",
  "hmac",
@@ -2897,7 +2971,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#eb60dd09b6c67ea1d1d0044ff6531d2e6821d4bf"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#e3a6c34961afe2fea9d0835a11548cc2500c0dcf"
 dependencies = [
  "hashbrown 0.14.0",
  "keyed-set",
@@ -2911,7 +2985,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#eb60dd09b6c67ea1d1d0044ff6531d2e6821d4bf"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#e3a6c34961afe2fea9d0835a11548cc2500c0dcf"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2930,7 +3004,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#eb60dd09b6c67ea1d1d0044ff6531d2e6821d4bf"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#e3a6c34961afe2fea9d0835a11548cc2500c0dcf"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2947,7 +3021,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#eb60dd09b6c67ea1d1d0044ff6531d2e6821d4bf"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#e3a6c34961afe2fea9d0835a11548cc2500c0dcf"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -2957,9 +3031,9 @@ dependencies = [
  "log",
  "quinn",
  "rustls",
- "rustls-native-certs",
- "rustls-pemfile",
- "rustls-webpki",
+ "rustls-native-certs 0.7.0",
+ "rustls-pemfile 2.0.0",
+ "rustls-webpki 0.102.0",
  "secrecy",
  "zenoh-config",
  "zenoh-core",
@@ -2973,7 +3047,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#eb60dd09b6c67ea1d1d0044ff6531d2e6821d4bf"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#e3a6c34961afe2fea9d0835a11548cc2500c0dcf"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2989,7 +3063,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#eb60dd09b6c67ea1d1d0044ff6531d2e6821d4bf"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#e3a6c34961afe2fea9d0835a11548cc2500c0dcf"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -2998,8 +3072,8 @@ dependencies = [
  "futures",
  "log",
  "rustls",
- "rustls-pemfile",
- "rustls-webpki",
+ "rustls-pemfile 2.0.0",
+ "rustls-webpki 0.102.0",
  "secrecy",
  "webpki-roots",
  "zenoh-config",
@@ -3014,7 +3088,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#eb60dd09b6c67ea1d1d0044ff6531d2e6821d4bf"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#e3a6c34961afe2fea9d0835a11548cc2500c0dcf"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3033,7 +3107,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#eb60dd09b6c67ea1d1d0044ff6531d2e6821d4bf"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#e3a6c34961afe2fea9d0835a11548cc2500c0dcf"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3051,7 +3125,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#eb60dd09b6c67ea1d1d0044ff6531d2e6821d4bf"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#e3a6c34961afe2fea9d0835a11548cc2500c0dcf"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3071,7 +3145,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#eb60dd09b6c67ea1d1d0044ff6531d2e6821d4bf"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#e3a6c34961afe2fea9d0835a11548cc2500c0dcf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3084,7 +3158,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#eb60dd09b6c67ea1d1d0044ff6531d2e6821d4bf"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#e3a6c34961afe2fea9d0835a11548cc2500c0dcf"
 dependencies = [
  "libloading",
  "log",
@@ -3097,7 +3171,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#eb60dd09b6c67ea1d1d0044ff6531d2e6821d4bf"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#e3a6c34961afe2fea9d0835a11548cc2500c0dcf"
 dependencies = [
  "const_format",
  "hex",
@@ -3133,7 +3207,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#eb60dd09b6c67ea1d1d0044ff6531d2e6821d4bf"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#e3a6c34961afe2fea9d0835a11548cc2500c0dcf"
 dependencies = [
  "anyhow",
 ]
@@ -3141,10 +3215,10 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#eb60dd09b6c67ea1d1d0044ff6531d2e6821d4bf"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#e3a6c34961afe2fea9d0835a11548cc2500c0dcf"
 dependencies = [
  "async-std",
- "event-listener",
+ "event-listener 4.0.0",
  "flume",
  "futures",
  "tokio",
@@ -3156,7 +3230,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#eb60dd09b6c67ea1d1d0044ff6531d2e6821d4bf"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#e3a6c34961afe2fea9d0835a11548cc2500c0dcf"
 dependencies = [
  "async-executor",
  "async-global-executor",
@@ -3187,7 +3261,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#eb60dd09b6c67ea1d1d0044ff6531d2e6821d4bf"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#e3a6c34961afe2fea9d0835a11548cc2500c0dcf"
 dependencies = [
  "async-std",
  "async-trait",


### PR DESCRIPTION
Automated synchronization of Cargo.lock and/or rust-toolchain.toml with Zenoh. This is necessary to ensure plugin ABI compatibility.