### PR TITLE
Fix Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [x86_64, i686, aarch64, armv7]
+        target: [x86_64, i686, armv7]
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
@@ -66,6 +66,28 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: auto
+          args: --release --out dist
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+
+  linux-aarch64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build wheels
+        uses: messense/maturin-action@v1
+        with:
+          target: aarch64
+          # NOTE(fuzzypixelz): We manually specify a more recent manylinux platform tag for aarch64:
+          # - zenoh-link-quic indirectly depends on ring 0.17 through rustls-webpki.
+          # - ring 0.17 depends on a version of BoringSSL that requires GCC/Clang to provide __ARM_ARCH
+          # - When setting the manylinux tag to 'auto', messense/maturin-action@v1 uses manylinux2014 to compile for for aarch64
+          # - the GCC included in the manylinux2014 docker image doesn't provide __ARM_ARCH
+          # See: https://github.com/briansmith/ring/issues/1728
+          manylinux: manylinux_2_28
           args: --release --out dist
       - name: Upload wheels
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Context

   - zenoh-link-quic [now](https://github.com/eclipse-zenoh/zenoh/pull/607/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R130) [indirectly](https://github.com/rustls/webpki/commit/29b8d270e67e9670ceef86dc06062cd043859b56) depends on ring 0.17 through rustls-webpki.
   - ring 0.17 depends on a version of BoringSSL that requires GCC/Clang to provide [__ARM_ARCH](https://boringssl.googlesource.com/boringssl/+/refs/heads/chromium-stable/include/openssl/arm_arch.h#84)
   - When setting the manylinux tag to 'auto', [messense/maturin-action@v1](https://github.com/PyO3/maturin-action#manylinux-docker-container) uses the manylinux2014 docker image to compile for for aarch64
   - the GCC included in the manylinux2014 docker image doesn't provide __ARM_ARCH
 
This was reported and discussed here: https://github.com/briansmith/ring/issues/1728. Naturally, the Release workflow is [broken](https://github.com/eclipse-zenoh/zenoh-python/actions/runs/7189499412/job/19581118659). Still, I can't tell why manylinux2014 is still working for armv7.

## Changes

As a workaround, this PR specifies `manylinux_2_28` for (and only for) the Linux Aarch64 target. This way, the other targets can still enjoy greater compatibility with (older) Linux distros.