### PR TITLE
Sync `Cargo.lock` and/or `rust-toolchain.toml` with Zenoh's

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2856,7 +2856,7 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 [[package]]
 name = "zenoh"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d8c27a6e017938f4435d5abea4a0142c9d23ff59"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#256b07ee973392516b53356ca19ef770aab8f744"
 dependencies = [
  "async-global-executor",
  "async-std",
@@ -2904,7 +2904,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d8c27a6e017938f4435d5abea4a0142c9d23ff59"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#256b07ee973392516b53356ca19ef770aab8f744"
 dependencies = [
  "zenoh-collections",
 ]
@@ -2912,7 +2912,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d8c27a6e017938f4435d5abea4a0142c9d23ff59"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#256b07ee973392516b53356ca19ef770aab8f744"
 dependencies = [
  "log",
  "serde",
@@ -2924,12 +2924,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d8c27a6e017938f4435d5abea4a0142c9d23ff59"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#256b07ee973392516b53356ca19ef770aab8f744"
 
 [[package]]
 name = "zenoh-config"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d8c27a6e017938f4435d5abea4a0142c9d23ff59"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#256b07ee973392516b53356ca19ef770aab8f744"
 dependencies = [
  "flume",
  "json5",
@@ -2948,7 +2948,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d8c27a6e017938f4435d5abea4a0142c9d23ff59"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#256b07ee973392516b53356ca19ef770aab8f744"
 dependencies = [
  "async-std",
  "lazy_static",
@@ -2958,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d8c27a6e017938f4435d5abea4a0142c9d23ff59"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#256b07ee973392516b53356ca19ef770aab8f744"
 dependencies = [
  "aes",
  "hmac",
@@ -2971,7 +2971,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d8c27a6e017938f4435d5abea4a0142c9d23ff59"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#256b07ee973392516b53356ca19ef770aab8f744"
 dependencies = [
  "hashbrown 0.14.0",
  "keyed-set",
@@ -2985,7 +2985,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d8c27a6e017938f4435d5abea4a0142c9d23ff59"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#256b07ee973392516b53356ca19ef770aab8f744"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3004,7 +3004,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d8c27a6e017938f4435d5abea4a0142c9d23ff59"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#256b07ee973392516b53356ca19ef770aab8f744"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3021,7 +3021,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d8c27a6e017938f4435d5abea4a0142c9d23ff59"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#256b07ee973392516b53356ca19ef770aab8f744"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -3047,7 +3047,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d8c27a6e017938f4435d5abea4a0142c9d23ff59"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#256b07ee973392516b53356ca19ef770aab8f744"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3063,7 +3063,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d8c27a6e017938f4435d5abea4a0142c9d23ff59"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#256b07ee973392516b53356ca19ef770aab8f744"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -3088,7 +3088,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d8c27a6e017938f4435d5abea4a0142c9d23ff59"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#256b07ee973392516b53356ca19ef770aab8f744"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3107,7 +3107,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d8c27a6e017938f4435d5abea4a0142c9d23ff59"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#256b07ee973392516b53356ca19ef770aab8f744"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3125,7 +3125,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d8c27a6e017938f4435d5abea4a0142c9d23ff59"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#256b07ee973392516b53356ca19ef770aab8f744"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3145,7 +3145,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d8c27a6e017938f4435d5abea4a0142c9d23ff59"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#256b07ee973392516b53356ca19ef770aab8f744"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3158,7 +3158,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d8c27a6e017938f4435d5abea4a0142c9d23ff59"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#256b07ee973392516b53356ca19ef770aab8f744"
 dependencies = [
  "libloading",
  "log",
@@ -3171,7 +3171,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d8c27a6e017938f4435d5abea4a0142c9d23ff59"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#256b07ee973392516b53356ca19ef770aab8f744"
 dependencies = [
  "const_format",
  "hex",
@@ -3207,7 +3207,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d8c27a6e017938f4435d5abea4a0142c9d23ff59"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#256b07ee973392516b53356ca19ef770aab8f744"
 dependencies = [
  "anyhow",
 ]
@@ -3215,7 +3215,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d8c27a6e017938f4435d5abea4a0142c9d23ff59"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#256b07ee973392516b53356ca19ef770aab8f744"
 dependencies = [
  "async-std",
  "event-listener 4.0.0",
@@ -3230,7 +3230,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d8c27a6e017938f4435d5abea4a0142c9d23ff59"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#256b07ee973392516b53356ca19ef770aab8f744"
 dependencies = [
  "async-executor",
  "async-global-executor",
@@ -3261,7 +3261,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.11.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#d8c27a6e017938f4435d5abea4a0142c9d23ff59"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=master#256b07ee973392516b53356ca19ef770aab8f744"
 dependencies = [
  "async-std",
  "async-trait",


### PR DESCRIPTION
Automated synchronization of Cargo.lock and/or rust-toolchain.toml with Zenoh. This is necessary to ensure plugin ABI compatibility.