### PR TITLE
Align examples and remove reading from stdin

### DIFF
--- a/examples/z_pub.py
+++ b/examples/z_pub.py
@@ -74,6 +74,7 @@ def main():
     print(f"Declaring Publisher on '{key}'...")
     pub = session.declare_publisher(key)
 
+    print("Press CTRL-C to quit...")
     for idx in itertools.count() if args.iter is None else range(args.iter):
         time.sleep(1)
         buf = f"[{idx:4d}] {value}"

--- a/examples/z_pub_thr.py
+++ b/examples/z_pub_thr.py
@@ -69,6 +69,7 @@ def main():
     session = zenoh.open(conf)
     pub = session.declare_publisher('test/thr', congestion_control=congestion_control)
 
+    print("Press CTRL-C to quit...")
     while True:
         pub.put(data)
 

--- a/examples/z_pull.py
+++ b/examples/z_pull.py
@@ -12,6 +12,7 @@
 #   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 #
 
+import itertools
 import sys
 import time
 from datetime import datetime
@@ -73,17 +74,13 @@ def main():
     session = zenoh.open(conf)
 
     print("Declaring Subscriber on '{}'...".format(key))
-
     sub = session.declare_pull_subscriber(key, listen, reliability=Reliability.RELIABLE())
 
-    print("Press <enter> to pull data...")
-    c = '\0'
-    while c != 'q':
-        c = sys.stdin.read(1)
-        if c == '':
-            time.sleep(1)
-        else:
-            sub.pull()
+    print("Press CTRL-C to quit...")
+    for idx in itertools.count():
+        time.sleep(1)
+        print(f"[{idx:4d}] Pulling...")
+        sub.pull()
 
     sub.undeclare()
     session.close()

--- a/examples/z_queryable.py
+++ b/examples/z_queryable.py
@@ -84,14 +84,9 @@ def main():
     print("Declaring Queryable on '{}'...".format(key))
     queryable = session.declare_queryable(key, queryable_callback, complete)
 
-    print("Enter 'q' to quit...")
-    c = '\0'
-    while c != 'q':
-        c = sys.stdin.read(1)
-        if c != 'q':
-            print("getting")
-            session.get(key, print, consolidation=zenoh.QueryConsolidation.NONE())
-            time.sleep(1)
+    print("Press CTRL-C to quit...")
+    while True:
+        time.sleep(1)
 
     queryable.undeclare()
     session.close()

--- a/examples/z_storage.py
+++ b/examples/z_storage.py
@@ -98,12 +98,9 @@ def main():
     print("Declaring Queryable on '{}'...".format(key))
     queryable = session.declare_queryable(key, query_handler, complete)
 
-    print("Enter 'q' to quit...")
-    c = '\0'
-    while c != 'q':
-        c = sys.stdin.read(1)
-        if c == '':
-            time.sleep(1)
+    print("Press CTRL-C to quit...")
+    while True:
+        time.sleep(1)
 
     sub.undeclare()
     queryable.undeclare()

--- a/examples/z_sub.py
+++ b/examples/z_sub.py
@@ -78,12 +78,9 @@ def main():
     # will be immediately undeclared.
     sub = session.declare_subscriber(key, listener, reliability=Reliability.RELIABLE())
 
-    print("Enter 'q' to quit...")
-    c = '\0'
-    while c != 'q':
-        c = sys.stdin.read(1)
-        if c == '':
-            time.sleep(1)
+    print("Press CTRL-C to quit...")
+    while True:
+        time.sleep(1)
 
     # Cleanup: note that even if you forget it, cleanup will happen automatically when 
     # the reference counter reaches 0

--- a/examples/z_sub_queued.py
+++ b/examples/z_sub_queued.py
@@ -84,12 +84,9 @@ def main():
 
     t = Thread(target=consumer)
     t.start()
-    print("Enter 'q' to quit...")
-    c = '\0'
-    while c != 'q':
-        c = sys.stdin.read(1)
-        if c == '':
-            time.sleep(1)
+    print("Press CTRL-C to quit...")
+    while True:
+        time.sleep(1)
 
     # Cleanup: note that even if you forget it, cleanup will happen automatically when 
     # the reference counter reaches 0

--- a/examples/z_sub_thr.py
+++ b/examples/z_sub_thr.py
@@ -96,12 +96,9 @@ def main():
     # Only do this if your callback runs faster than the minimum expected delay between two samples.
     sub = session.declare_subscriber("test/thr", zenoh.Closure((listener, report)), reliability=Reliability.RELIABLE())
 
-    print("Enter 'q' to quit...")
-    c = '\0'
-    while c != 'q':
-        c = sys.stdin.read(1)
-        if c == '':
-            time.sleep(1)
+    print("Press CTRL-C to quit...")
+    while True:
+        time.sleep(1)
 
     sub.undeclare()
     session.close()


### PR DESCRIPTION
These changes remove reading from stdin for all examples, and align their behaviors and outputs across projects. Closes #144

This PR is part of an effort across currently active Zenoh projects. To maintain examples' implementations as close to each other as possible, any changes identified in other projects will be replicated in this PR. As such, **please do not merge these changes until all PRs are ready for merging**.

Related PRs:
- https://github.com/eclipse-zenoh/zenoh/pull/768
- https://github.com/eclipse-zenoh/zenoh-c/pull/255
- https://github.com/eclipse-zenoh/zenoh-cpp/pull/103
- https://github.com/eclipse-zenoh/zenoh-java/pull/45
- https://github.com/eclipse-zenoh/zenoh-kotlin/pull/47
- https://github.com/eclipse-zenoh/zenoh-pico/pull/359