### PR TITLE
fix: Documentation build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -27,6 +27,7 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.8"
+    rust: "latest"
 
 # Build documentation with MkDocs
 #mkdocs:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -28,10 +28,9 @@ build:
   tools:
     python: "3.8"
     rust: "latest"
-
-# Build documentation with MkDocs
-#mkdocs:
-#  configuration: mkdocs.yml
+  jobs:
+    pre_build:
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH maturin develop
 
 # Optionally build your docs in additional formats such as PDF
 formats:
@@ -41,3 +40,4 @@ formats:
 python:
   install:
     - requirements: docs/requirements.txt
+    - requirements: requirements-dev.txt

--- a/README.md
+++ b/README.md
@@ -29,11 +29,6 @@ Install the latest available version using `pip`:
 pip install eclipse-zenoh
 ```
 
-To install the latest nightly build of the development version do:
-```
-pip install eclipse-zenoh-nightly
-```
-
 :warning:WARNING:warning: zenoh-python is developped in Rust.
 On Pypi.org we provide binary wheels for the most common platforms (Linux x86_64, i686, ARMs, MacOS universal2 and Windows amd64). But also a source distribution package for other platforms.
 However, for `pip` to be able to build this source distribution, there are some prerequisites:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,9 +23,6 @@
 
 # -- Project setup --------------------------------------------------------------
 
-# NOTE: as zenoh-python is developped in Rust, it must be compiled and install in Python environment
-# in order to be imported here (and the Sphinx autodoc extension to load the doc from the compiled code)
-# For readthedocs.org, zenoh-python is added in docs/requirements.txt so it get it from pypi.org
 import zenoh
 
 # -- Project information -----------------------------------------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,1 @@
-### NOTE: Read the Docs cannot build the Rust code, and thus is not able to import zenoh
-### unless it's installed from pypi.org as a requirement
-eclipse-zenoh == 0.11.0-dev
+sphinx_rtd_theme==2.0.0


### PR DESCRIPTION
Resolves https://github.com/eclipse-zenoh/zenoh-python/issues/151.

Originally, the documentation build relied on the eclipse-zenoh-nightly PyPI package, which is not actively maintained currently. However, it is possible to build this crate from source in Read the Docs are they offer Rust toolchains.