### PR TITLE
chore: bump pyo3 to 0.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
  "log",
  "parking",
  "polling",
- "rustix 0.37.25",
+ "rustix",
  "slab",
  "socket2 0.4.9",
  "waker-fn",
@@ -198,7 +198,7 @@ dependencies = [
  "cfg-if",
  "event-listener 2.5.3",
  "futures-lite",
- "rustix 0.37.25",
+ "rustix",
  "signal-hook",
  "windows-sys 0.48.0",
 ]
@@ -524,22 +524,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.10.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c012a26a7f605efc424dd53697843a72be7dc86ad2d01f7814337794a12231d"
+checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -821,6 +808,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "1.0.9"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "inout"
@@ -929,17 +922,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
-dependencies = [
- "hermit-abi",
- "rustix 0.38.13",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1033,12 +1015,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
-
-[[package]]
 name = "lock_api"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 dependencies = [
  "value-bag",
 ]
@@ -1074,9 +1050,9 @@ checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "memoffset"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
@@ -1408,6 +1384,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,15 +1412,16 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.18.3"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b1ac5b3731ba34fdaa9785f8d74d17448cd18f30cf19e0c7e7b1fdb5272109"
+checksum = "a7a8b1990bd018761768d5e608a13df8bd1ac5f678456e0f301bb93e5f3ea16b"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
  "memoffset",
  "parking_lot",
+ "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -1447,9 +1430,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.18.3"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cb946f5ac61bb61a5014924910d936ebd2b23b705f7a4a3c40b05c720b079a3"
+checksum = "650dca34d463b6cdbdb02b1d71bfd6eb6b6816afc708faebb3bac1380ff4aef7"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1457,9 +1440,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.18.3"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd4d7c5337821916ea2a1d21d1092e8443cf34879e53a0ac653fbb98f44ff65c"
+checksum = "09a7da8fc04a8a2084909b59f29e1b8474decac98b951d77b80b26dc45f046ad"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1467,25 +1450,27 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.18.3"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d39c55dab3fc5a4b25bbd1ac10a2da452c4aca13bb450f22818a002e29648d"
+checksum = "4b8a199fce11ebb28e3569387228836ea98110e43a804a530a9fd83ade36d513"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.33",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.18.3"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97daff08a4c48320587b5224cc98d609e3c27b6d437315bd40b605c98eeb5918"
+checksum = "93fbbfd7eb553d10036513cb122b888dcd362a945a00b06c165f2ab480d4cc3b"
 dependencies = [
+ "heck",
  "proc-macro2",
+ "pyo3-build-config",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.33",
 ]
 
 [[package]]
@@ -1725,20 +1710,7 @@ dependencies = [
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rustix"
-version = "0.38.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
-dependencies = [
- "bitflags 2.4.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.7",
+ "linux-raw-sys",
  "windows-sys 0.48.0",
 ]
 
@@ -2171,15 +2143,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2416,9 +2379,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unindent"
-version = "0.1.11"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1766d682d402817b5ac4490b3c3002d91dfa0d22812f341609f97b08757359c"
+checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -2507,9 +2470,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag"
-version = "1.4.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92ccd67fb88503048c01b59152a04effd0782d035a83a6d256ce6085f08f4a3"
+checksum = "74797339c3b98616c009c7c3eb53a0ce41e85c8ec66bd3db96ed132d20cfdee8"
 
 [[package]]
 name = "vec_map"
@@ -2635,15 +2598,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -2791,7 +2745,7 @@ dependencies = [
  "async-trait",
  "base64",
  "const_format",
- "env_logger 0.11.2",
+ "env_logger",
  "event-listener 4.0.0",
  "flume",
  "form_urlencoded",
@@ -3138,7 +3092,7 @@ dependencies = [
 name = "zenoh-python"
 version = "0.11.0-dev"
 dependencies = [
- "env_logger 0.10.2",
+ "env_logger",
  "flume",
  "json5",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,10 +41,10 @@ default = ["zenoh/default"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-env_logger = "0.10.0"
+env_logger = "0.11.3"
 flume = "0.11.0"
 json5 = "0.4.1"
-pyo3 = { version = "0.18.1", features = ["extension-module", "abi3-py37"] }
+pyo3 = { version = "0.21.1", features = ["extension-module", "abi3-py37"] }
 uhlc = "0.6.0"
 validated_struct = "2.1.0"
 zenoh = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", features = ["unstable"], default-features = false }

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,7 +63,7 @@ impl _Config {
     pub fn from_json5(expr: &str) -> PyResult<Self> {
         match Config::from_deserializer(&mut json5::Deserializer::from_str(expr).to_pyres()?) {
             Ok(k) => Ok(Self(PyConfig::Config(Box::new(k)))),
-            Err(Ok(_)) => Err(zenoh_core::zerror!(
+            Err(Ok(_)) => Err(zerror!(
                 "{} did parse into a config, but invalid values were found",
                 expr,
             )

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -147,7 +147,7 @@ impl _Priority {
         }
     }
 }
-impl std::cmp::PartialOrd for _Priority {
+impl PartialOrd for _Priority {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         (self.0 as u8).partial_cmp(&(other.0 as u8))
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -44,7 +44,7 @@ pub struct _Session(pub(crate) Arc<Session>);
 #[pymethods]
 impl _Session {
     #[new]
-    pub fn new(mut config: Option<&mut crate::config::_Config>) -> PyResult<Self> {
+    pub fn new(mut config: Option<&mut _Config>) -> PyResult<Self> {
         let c = match &mut config {
             Some(c) => c.0.take().unwrap_or_default(),
             None => Default::default(),
@@ -62,9 +62,9 @@ impl _Session {
     #[pyo3(signature = (key_expr, value, **kwargs))]
     pub fn put(
         &self,
-        key_expr: &crate::keyexpr::_KeyExpr,
-        value: &PyAny,
-        kwargs: Option<&PyDict>,
+        key_expr: &_KeyExpr,
+        value: &Bound<PyAny>,
+        kwargs: Option<&Bound<PyDict>>,
     ) -> PyResult<()> {
         let s = &self.0;
         let k = &key_expr.0;
@@ -95,8 +95,8 @@ impl _Session {
     #[pyo3(signature = (key_expr, **kwargs))]
     pub fn delete(
         &self,
-        key_expr: &crate::keyexpr::_KeyExpr,
-        kwargs: Option<&PyDict>,
+        key_expr: &_KeyExpr,
+        kwargs: Option<&Bound<PyDict>>,
     ) -> PyResult<()> {
         let s = &self.0;
         let k = &key_expr.0;
@@ -127,8 +127,8 @@ impl _Session {
     pub fn get(
         &self,
         selector: &_Selector,
-        callback: &PyAny,
-        kwargs: Option<&PyDict>,
+        callback: &Bound<PyAny>,
+        kwargs: Option<&Bound<PyDict>>,
     ) -> PyResult<()> {
         let callback: PyClosure<(_Reply,)> = <_ as TryInto<_>>::try_into(callback)?;
         let mut builder = self.0.get(&selector.0).with(callback);
@@ -163,8 +163,8 @@ impl _Session {
     pub fn declare_queryable(
         &self,
         key_expr: _KeyExpr,
-        callback: &PyAny,
-        kwargs: Option<&PyDict>,
+        callback: &Bound<PyAny>,
+        kwargs: Option<&Bound<PyDict>>,
     ) -> PyResult<_Queryable> {
         let callback: PyClosure<(_Query,)> = <_ as TryInto<_>>::try_into(callback)?;
         let mut builder = self.0.declare_queryable(key_expr.0).with(callback);
@@ -185,7 +185,7 @@ impl _Session {
     pub fn declare_publisher(
         &self,
         key_expr: _KeyExpr,
-        kwargs: Option<&PyDict>,
+        kwargs: Option<&Bound<PyDict>>,
     ) -> PyResult<_Publisher> {
         let mut builder = self.0.declare_publisher(key_expr.0);
         if let Some(kwargs) = kwargs {
@@ -210,8 +210,8 @@ impl _Session {
     pub fn declare_subscriber(
         &self,
         key_expr: &_KeyExpr,
-        callback: &PyAny,
-        kwargs: Option<&PyDict>,
+        callback: &Bound<PyAny>,
+        kwargs: Option<&Bound<PyDict>>,
     ) -> PyResult<_Subscriber> {
         let callback: PyClosure<(_Sample,)> = <_ as TryInto<_>>::try_into(callback)?;
         let mut builder = self.0.declare_subscriber(&key_expr.0).with(callback);
@@ -230,8 +230,8 @@ impl _Session {
     pub fn declare_pull_subscriber(
         &self,
         key_expr: &_KeyExpr,
-        callback: &PyAny,
-        kwargs: Option<&PyDict>,
+        callback: &Bound<PyAny>,
+        kwargs: Option<&Bound<PyDict>>,
     ) -> PyResult<_PullSubscriber> {
         let callback: PyClosure<(_Sample,)> = <_ as TryInto<_>>::try_into(callback)?;
         let mut builder = self
@@ -303,7 +303,7 @@ impl _PullSubscriber {
 pub struct _Scout(Scout<()>);
 
 #[pyfunction]
-pub fn scout(callback: &PyAny, config: Option<&_Config>, what: Option<&str>) -> PyResult<_Scout> {
+pub fn scout(callback: &Bound<PyAny>, config: Option<&_Config>, what: Option<&str>) -> PyResult<_Scout> {
     let callback: PyClosure<(_Hello,)> = <_ as TryInto<_>>::try_into(callback)?;
     let what: WhatAmIMatcher = match what {
         None => WhatAmI::Client | WhatAmI::Peer | WhatAmI::Router,

--- a/src/value.rs
+++ b/src/value.rs
@@ -47,7 +47,7 @@ impl Payload {
                 let len = buf.len();
                 Python::with_gil(|py| {
                     Py::from(
-                        PyBytes::new_with(py, len, |mut bytes| {
+                        PyBytes::new_bound_with(py, len, |mut bytes| {
                             for slice in buf.slices() {
                                 let len = slice.len();
                                 bytes[..len].copy_from_slice(slice);
@@ -152,7 +152,7 @@ impl From<_Value> for Value {
 pub(crate) trait PyAnyToValue {
     fn to_value(self) -> PyResult<Value>;
 }
-impl PyAnyToValue for &PyAny {
+impl PyAnyToValue for &Bound<'_, PyAny> {
     fn to_value(self) -> PyResult<Value> {
         let encoding: _Encoding = self.getattr("encoding")?.extract()?;
         let payload: &PyBytes = self.getattr("payload")?.extract()?;


### PR DESCRIPTION
Roughly adapt the code to the new PyO3 API, with a few warning fixes.