### PR TITLE
Fix: force sphinx version to 7.2.6 for readthedocs build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
+sphinx==7.2.6
 sphinx_rtd_theme==2.0.0


### PR DESCRIPTION
This PR fixes the readthedocs build failure in CI. 