### PR TITLE
fix: Install maturin according to `requirements-dev.txt`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,7 @@ jobs:
           export AR_arm_unknown_linux_gnueabihf=arm-unknown-linux-gnueabihf-ar
           export CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-unknown-linux-gnueabihf-gcc
 
-          pip3 install maturin
+          pip3 install -r requirements-dev.txt
           maturin build --release --target arm-unknown-linux-gnueabihf --out dist
 
       - name: Upload wheels


### PR DESCRIPTION
The existing command installs maturin 1.5 for the build-linux-armv6, instead of the version defined in dev-requirements.txt and the version used by the other jobs.