### PR TITLE
fix: remove deprecated maturin arg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,8 @@ jobs:
       - name: Build wheels - universal2
         uses: messense/maturin-action@v1
         with:
-          args: --release --universal2 --out dist
+          target: universal2-apple-darwin
+          args: --release --out dist
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
See https://github.com/PyO3/maturin/pull/1620, `--universal2` has been deprecated