### PR TITLE
Use default consolidation config in z_get example

### DIFF
--- a/examples/z_get.py
+++ b/examples/z_get.py
@@ -108,7 +108,6 @@ def main():
             selector,
             target=target,
             payload=args.payload,
-            consolidation=zenoh.ConsolidationMode.NONE,
         )
         for reply in replies:
             try:

--- a/examples/z_get.py
+++ b/examples/z_get.py
@@ -104,11 +104,7 @@ def main():
     print("Opening session...")
     with zenoh.open(conf) as session:
         print("Sending Query '{}'...".format(selector))
-        replies = session.get(
-            selector,
-            target=target,
-            payload=args.payload,
-        )
+        replies = session.get(selector, target=target, payload=args.payload)
         for reply in replies:
             try:
                 print(


### PR DESCRIPTION
Will use default config of consolidation (AUTO) to align with other implementations of `z_get`.