### PR TITLE
Use init_log_from_env_or for examples

### DIFF
--- a/examples/z_delete.py
+++ b/examples/z_delete.py
@@ -16,7 +16,7 @@ import zenoh
 
 def main(conf: zenoh.Config, key: str):
     # initiate logging
-    zenoh.try_init_log_from_env()
+    zenoh.init_log_from_env_or("error")
 
     print("Opening session...")
     with zenoh.open(conf) as session:

--- a/examples/z_get.py
+++ b/examples/z_get.py
@@ -16,7 +16,7 @@ import zenoh
 
 def main(conf: zenoh.Config, selector: str, target: zenoh.QueryTarget, payload: str):
     # initiate logging
-    zenoh.try_init_log_from_env()
+    zenoh.init_log_from_env_or("error")
 
     print("Opening session...")
     with zenoh.open(conf) as session:

--- a/examples/z_info.py
+++ b/examples/z_info.py
@@ -16,7 +16,7 @@ import zenoh
 
 def main(conf: zenoh.Config):
     # initiate logging
-    zenoh.try_init_log_from_env()
+    zenoh.init_log_from_env_or("error")
 
     print("Opening session...")
     with zenoh.open(conf) as session:

--- a/examples/z_ping.py
+++ b/examples/z_ping.py
@@ -18,7 +18,7 @@ import zenoh
 
 def main(conf: zenoh.Config, payload_size: int, warmup: int, samples: int):
     # initiate logging
-    zenoh.try_init_log_from_env()
+    zenoh.init_log_from_env_or("error")
 
     print("Opening session...")
     with zenoh.open(conf) as session:

--- a/examples/z_pong.py
+++ b/examples/z_pong.py
@@ -18,7 +18,7 @@ import zenoh
 
 def main(conf: zenoh.Config, express: bool):
     # initiate logging
-    zenoh.try_init_log_from_env()
+    zenoh.init_log_from_env_or("error")
 
     print("Opening session...")
     with zenoh.open(conf) as session:

--- a/examples/z_pub.py
+++ b/examples/z_pub.py
@@ -18,7 +18,7 @@ import zenoh
 
 def main(conf: zenoh.Config, key: str, payload: str, iter: int, interval: int):
     # initiate logging
-    zenoh.try_init_log_from_env()
+    zenoh.init_log_from_env_or("error")
 
     print("Opening session...")
     with zenoh.open(conf) as session:

--- a/examples/z_pub_thr.py
+++ b/examples/z_pub_thr.py
@@ -16,7 +16,7 @@ import zenoh
 
 def main(conf: zenoh.Config, payload_size: int):
     # initiate logging
-    zenoh.try_init_log_from_env()
+    zenoh.init_log_from_env_or("error")
 
     data = bytearray()
     for i in range(0, payload_size):

--- a/examples/z_pull.py
+++ b/examples/z_pull.py
@@ -18,7 +18,7 @@ import zenoh
 
 def main(conf: zenoh.Config, key: str, size: int, interval: int):
     # initiate logging
-    zenoh.try_init_log_from_env()
+    zenoh.init_log_from_env_or("error")
 
     print("Opening session...")
     with zenoh.open(conf) as session:

--- a/examples/z_put.py
+++ b/examples/z_put.py
@@ -16,7 +16,7 @@ import zenoh
 
 def main(conf: zenoh.Config, key: str, payload: str):
     # initiate logging
-    zenoh.try_init_log_from_env()
+    zenoh.init_log_from_env_or("error")
 
     print("Opening session...")
     with zenoh.open(conf) as session:

--- a/examples/z_queryable.py
+++ b/examples/z_queryable.py
@@ -29,7 +29,7 @@ def main(conf: zenoh.Config, key: str, payload: str, complete: bool):
         query.reply(key, payload)
 
     # initiate logging
-    zenoh.try_init_log_from_env()
+    zenoh.init_log_from_env_or("error")
 
     print("Opening session...")
     with zenoh.open(conf) as session:

--- a/examples/z_scout.py
+++ b/examples/z_scout.py
@@ -18,7 +18,7 @@ import zenoh
 
 def main():
     # initiate logging
-    zenoh.try_init_log_from_env()
+    zenoh.init_log_from_env_or("error")
 
     print("Scouting...")
     scout = zenoh.scout(what="peer|router")

--- a/examples/z_storage.py
+++ b/examples/z_storage.py
@@ -47,7 +47,7 @@ def query_handler(query: zenoh.Query):
 
 def main(conf: zenoh.Config, key: str, complete: bool):
     # initiate logging
-    zenoh.try_init_log_from_env()
+    zenoh.init_log_from_env_or("error")
 
     print("Opening session...")
     with zenoh.open(conf) as session:

--- a/examples/z_sub.py
+++ b/examples/z_sub.py
@@ -18,7 +18,7 @@ import zenoh
 
 def main(conf: zenoh.Config, key: str):
     # initiate logging
-    zenoh.try_init_log_from_env()
+    zenoh.init_log_from_env_or("error")
 
     print("Opening session...")
     with zenoh.open(conf) as session:

--- a/examples/z_sub_queued.py
+++ b/examples/z_sub_queued.py
@@ -16,7 +16,7 @@ import zenoh
 
 def main(conf: zenoh.Config, key: str):
     # initiate logging
-    zenoh.try_init_log_from_env()
+    zenoh.init_log_from_env_or("error")
 
     print("Opening session...")
     with zenoh.open(conf) as session:

--- a/examples/z_sub_thr.py
+++ b/examples/z_sub_thr.py
@@ -46,7 +46,7 @@ def main(conf: zenoh.Config, number: int):
         )
 
     # initiate logging
-    zenoh.try_init_log_from_env()
+    zenoh.init_log_from_env_or("error")
 
     with zenoh.open(conf) as session:
         session.declare_subscriber(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,11 @@ pub(crate) mod zenoh {
         zenoh::try_init_log_from_env();
     }
 
+    #[pyfunction]
+    fn init_log_from_env_or(level: &str) {
+        zenoh::init_log_from_env_or(level);
+    }
+
     #[pymodule_export]
     use crate::{
         bytes::{deserializer, serializer, Encoding, ZBytes},

--- a/zenoh/__init__.pyi
+++ b/zenoh/__init__.pyi
@@ -983,6 +983,12 @@ def try_init_log_from_env():
     For example, `RUST_LOG=debug` will set the log level to DEBUG.
     If `RUST_LOG` is not set, then logging is not enabled."""
 
+def init_log_from_env_or(level: str):
+    """Redirect zenoh logs to stdout, according to the `RUST_LOG` environment variable.
+
+    For example, `RUST_LOG=debug` will set the log level to DEBUG.
+    If `RUST_LOG` is not set, then logging is set to the provided level."""
+
 def open(config: Config) -> Session:
     """Open a zenoh Session."""
 


### PR DESCRIPTION
Use `init_log_from_env_or("error")` instead of `try_init_log_from_env` in examples.