### PR TITLE
fix: edit version for devel builds

### DIFF
--- a/ci/scripts/bump-and-tag.bash
+++ b/ci/scripts/bump-and-tag.bash
@@ -32,7 +32,7 @@ export GIT_COMMITTER_EMAIL=$git_user_email
 
 # For development releases (e.g. 1.0.0-dev-21-g2ca8632), transform the version
 # into a PEP-440 compatible version, since maturin>1 requires strict version compliance.
-if [[ "${version}" =~ [0-9]+\.[0-9]+\.[0-9]+-dev-[0-9]+-[a-z0-9]+ ]]; then
+if [[ "${version}" =~ [0-9]+\.[0-9]+\.[0-9]+-dev-[0-9]+-g[a-f0-9]+ ]]; then
   version=$(echo $version | sed 's/dev-/dev+/')
 
 # Bump Cargo version

--- a/ci/scripts/bump-and-tag.bash
+++ b/ci/scripts/bump-and-tag.bash
@@ -30,6 +30,11 @@ export GIT_AUTHOR_EMAIL=$git_user_email
 export GIT_COMMITTER_NAME=$git_user_name
 export GIT_COMMITTER_EMAIL=$git_user_email
 
+# For development releases (e.g. 1.0.0-dev-21-g2ca8632), transform the version
+# into a PEP-440 compatible version, since maturin>1 requires strict version compliance.
+if [[ "${version}" =~ [0-9]+\.[0-9]+\.[0-9]+-dev-[0-9]+-[a-z0-9]+ ]]; then
+  version=$(echo $version | sed 's/dev-/dev+/')
+
 # Bump Cargo version
 toml_set_in_place Cargo.toml "package.version" "$version"
 # Propagate version change to pyproject.toml

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,1 @@
-maturin>=0.13,<0.15
+maturin>1


### PR DESCRIPTION
On development builds, use a PEP-440 compatible version, since maturin>1 requires stricter version checking.

Here you can see the failure with the semver version: https://github.com/eclipse-zenoh/zenoh-python/actions/runs/10894902155/job/30232339459

I ran a build here: https://github.com/eclipse-zenoh/zenoh-python/actions/runs/10897575950 with the edited version string and maturin builds correctly.