### PR TITLE
chore: revert ci check back to ubuntu-latest after isort fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,7 @@ on:
 
 jobs:
   check:
-    # TODO put back ubuntu-latest when isort issue will be fixed
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Clone this repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Resolves #356

since https://github.com/isort/isort-action/issues/94 resolved, ci check job runner can be put back to ubuntu-latest