### PR TITLE
fix: Don't tag release branch during dry-run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Bump and tag project
         run: bash ci/scripts/bump-and-tag.bash
         env:
+          LIVE_RUN: ${{ inputs.live-run || false }}
           VERSION: ${{ steps.create-release-branch.outputs.version }}
           BUMP_DEPS_VERSION: ${{ inputs.zenoh-version }}
           BUMP_DEPS_PATTERN: ${{ inputs.zenoh-version && 'zenoh.*' || '' }}

--- a/ci/scripts/bump-and-tag.bash
+++ b/ci/scripts/bump-and-tag.bash
@@ -2,6 +2,7 @@
 
 set -xeo pipefail
 
+readonly live_run=${LIVE_RUN:-false}
 # Release number
 version=${VERSION:?input VERSION is required}
 # Dependencies' pattern
@@ -65,7 +66,9 @@ if [[ "$bump_deps_pattern" != '' ]]; then
   fi
 fi
 
-git tag --force "$version" -m "v$version"
+if [[ ${live_run} ]]; then
+  git tag --force "$version" -m "v$version"
+fi
 git log -10
 git show-ref --tags
 git push origin


### PR DESCRIPTION
Aligning with [ci repository](https://github.com/eclipse-zenoh/ci/pull/239) to not tag the repo when we are running release dry-run