### PR TITLE
Add CI for checking markdown format.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,15 @@ jobs:
       - name: Run pytest
         run: pytest -n auto --import-mode=append
 
+  markdown_lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DavidAnson/markdownlint-cli2-action@v18
+        with:
+          config: '.markdownlint.yaml'
+          globs: '**/README.md'
+
   # NOTE: In GitHub repository settings, the "Require status checks to pass
   # before merging" branch protection rule ensures that commits are only merged
   # from branches where specific status checks have passed. These checks are
@@ -87,7 +96,7 @@ jobs:
   ci:
     name: CI status checks
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, markdown_lint]
     if: always()
     steps:
       - name: Check whether all jobs pass

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,6 @@
+{
+  "MD013": false, # Line length limitation
+  "MD033": false, # Enable Inline HTML
+  "MD041": false, # Allow first line heading
+  "MD045": false, # Allow Images have no alternate text
+}


### PR DESCRIPTION
As https://github.com/eclipse-zenoh/zenoh/issues/1666, fix the README.md format and update CI.