### PR TITLE
fix: exclude internal from automatic changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -33,3 +33,6 @@ changelog:
     - title: Other changes
       labels:
         - "*"
+      exclude:
+        labels:
+          - internal


### PR DESCRIPTION
Don't include PRs labeled as internal in the automatically generated changelog