### PR TITLE
remove useless `IntoRust` bound in handlers system

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -37,14 +37,14 @@ impl<T, E: IntoPyErr> IntoPyResult<T> for Result<T, E> {
     }
 }
 
-pub(crate) trait IntoRust: Send + Sync + 'static {
+pub(crate) trait IntoRust: 'static {
     type Into;
     fn into_rust(self) -> Self::Into;
 }
 
 into_rust!(bool, Duration);
 
-pub(crate) trait IntoPython: Sized + Send + 'static {
+pub(crate) trait IntoPython: Sized + Send + Sync + 'static {
     type Into: IntoPy<PyObject>;
     fn into_python(self) -> Self::Into;
     fn into_pyobject(self, py: Python) -> PyObject {


### PR DESCRIPTION
Only the `IntoPython` bound is important, the rest was there to reinforce the typing, but it's not needed at all, and it prevented to use objects not implementing `IntoRust` (which will be the case when `Query` will use `option_wrapper`)