### PR TITLE
fix: update bump and tag for dev releases

### DIFF
--- a/ci/scripts/bump-and-tag.bash
+++ b/ci/scripts/bump-and-tag.bash
@@ -33,8 +33,8 @@ export GIT_COMMITTER_EMAIL=$git_user_email
 
 # For development releases (e.g. 1.0.0-dev-21-g2ca8632), transform the version
 # into a PEP-440 compatible version, since maturin>1 requires strict version compliance.
-if [[ "${version}" =~ [0-9]+\.[0-9]+\.[0-9]+-dev-[0-9]+-g[a-f0-9]+ ]]; then
-  version=$(echo $version | sed 's/dev-/dev+/')
+if [[ "${version}" =~ [0-9]+\.[0-9]+\.[0-9]+-[0-9]+-g[a-f0-9]+ ]]; then
+  version=$(echo $version | sed 's/-/+/')
 fi
 
 # Bump Cargo version


### PR DESCRIPTION
remove -dev suffix from version, since that's not used anymore. This should allow git describe tag to work with maturin

See https://github.com/eclipse-zenoh/zenoh-python/actions/runs/13960108853/job/39079789767#step:3:192