### PR TITLE
fix: can't pass socket address in cfg on python examples

### DIFF
--- a/examples/common/common.py
+++ b/examples/common/common.py
@@ -74,7 +74,7 @@ def get_config_from_args(args) -> zenoh.Config:
 
     for c in args.cfg:
         try:
-            [key, value] = c.split(":")
+            [key, value] = c.split(":", 1)
         except:
             print(f"`--cfg` argument: expected KEY:VALUE pair, got {c}")
             raise


### PR DESCRIPTION
The socket address contains colon which causes the below exception:
```
    [key, value] = c.split(":")
ValueError: too many values to unpack (expected 2)
```

This PR passing `maxsplit` on split to fix the error.