### PR TITLE
Update z_ping.py

### DIFF
--- a/examples/z_ping.py
+++ b/examples/z_ping.py
@@ -79,13 +79,6 @@ if __name__ == "__main__":
         type=int,
         help="Sets the size of the payload to publish.",
     )
-    parser.add_argument(
-        "--no-multicast-scouting",
-        dest="no_multicast_scouting",
-        default=False,
-        action="store_true",
-        help="Disable multicast scouting.",
-    )
 
     args = parser.parse_args()
     conf = common.get_config_from_args(args)


### PR DESCRIPTION
argument --no-multicast-scouting is already declared in common.py config arguments