### PR TITLE
chore: trust messense/macos-cross-toolchains

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,7 @@ jobs:
       - name: Install cross toolchain
         run: |
           brew tap messense/macos-cross-toolchains
-          brew trust messense/macos-cross-toolchains
+          brew trust --formula messense/macos-cross-toolchains/arm-unknown-linux-gnueabihf
           brew install arm-unknown-linux-gnueabihf
 
           export CC_arm_unknown_linux_gnueabihf=arm-unknown-linux-gnueabihf-gcc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,7 @@ jobs:
       - name: Install cross toolchain
         run: |
           brew tap messense/macos-cross-toolchains
+          brew trust messense/macos-cross-toolchains
           brew install arm-unknown-linux-gnueabihf
 
           export CC_arm_unknown_linux_gnueabihf=arm-unknown-linux-gnueabihf-gcc


### PR DESCRIPTION
Fix release.yml https://github.com/eclipse-zenoh/zenoh-python/actions/runs/29793705922/job/88520767602